### PR TITLE
Update super_native_extensions dependency

### DIFF
--- a/super_clipboard/pubspec.yaml
+++ b/super_clipboard/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     git:
       url: git@github.com:superlistapp/super_native_extensions.git
       path: super_native_extensions
-      ref: 4367349399b40c648c27a74b0d281b572bfa6331
+      ref: 57d753a83f65d0c6a02891dc46625c0b630208f4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Includes this commit: https://github.com/superlistapp/super_native_extensions/commit/57d753a83f65d0c6a02891dc46625c0b630208f4

which fixes an issue when running `pod install` in `superlist/ios`.