### PR TITLE
fix: rare crash while dragging on iOS

### DIFF
--- a/super_native_extensions/rust/src/darwin/ios/drop.rs
+++ b/super_native_extensions/rust/src/darwin/ios/drop.rs
@@ -38,7 +38,11 @@ use crate::{
     value_promise::PromiseResult,
 };
 
-use super::{drag_common::DropOperationExt, util::image_view_from_data, PlatformDataReader};
+use super::{
+    drag_common::DropOperationExt,
+    util::{image_view_from_data, IgnoreInteractionEvents},
+    PlatformDataReader,
+};
 
 pub struct PlatformDropContext {
     id: PlatformDropContextId,
@@ -190,6 +194,7 @@ impl Session {
             }),
         );
         let mut poll_session = PollSession::new();
+        let _ignore_events = IgnoreInteractionEvents::new();
         while !done.get() {
             RunLoop::current()
                 .platform_run_loop
@@ -325,6 +330,7 @@ impl Session {
             },
         );
         let mut poll_session = PollSession::new();
+        let _ignore_events = IgnoreInteractionEvents::new();
         loop {
             if let Some(result) = preview_promise.try_take() {
                 match result {

--- a/super_native_extensions/rust/src/darwin/ios/util.rs
+++ b/super_native_extensions/rust/src/darwin/ios/util.rs
@@ -223,3 +223,28 @@ pub fn image_view_from_data(image_data: ImageData) -> StrongPtr {
     let image_view: id = unsafe { msg_send![class!(UIImageView), alloc] };
     unsafe { StrongPtr::new(msg_send![image_view, initWithImage: image]) }
 }
+
+/// Ignores the notifications event while in scope.
+pub struct IgnoreInteractionEvents {}
+
+impl IgnoreInteractionEvents {
+    pub fn new() -> Self {
+        unsafe {
+            // beginIgnoringInteractionEvents is a large stick but we need one
+            // to prevent active drag gesture recognizer from getting events while
+            // waiting for drag data.
+            let app: id = msg_send![class!(UIApplication), sharedApplication];
+            let () = msg_send![app, beginIgnoringInteractionEvents];
+        }
+        Self {}
+    }
+}
+
+impl Drop for IgnoreInteractionEvents {
+    fn drop(&mut self) {
+        unsafe {
+            let app: id = msg_send![class!(UIApplication), sharedApplication];
+            let () = msg_send![app, endIgnoringInteractionEvents];
+        }
+    }
+}


### PR DESCRIPTION
Fixed by not sending touch events while pumping CFRunLoop when waiting for drag data.