### PR TITLE
fix: serialize invocation of drop events

### DIFF
--- a/super_native_extensions/lib/src/drop.dart
+++ b/super_native_extensions/lib/src/drop.dart
@@ -103,7 +103,7 @@ class ItemPreviewRequest {
     required this.fadeOutDuration,
   });
 
-  static deserialize(dynamic request) {
+  static ItemPreviewRequest deserialize(dynamic request) {
     final map = request as Map;
     return ItemPreviewRequest(
       sessionId: map['sessionId'] as int,


### PR DESCRIPTION
Otherwise there may be race condition where reader gets destroyed while previous drop event is being in progress.