### PR TITLE
fix: [windows] use cached length when reading virtual stream

### DIFF
--- a/super_native_extensions/rust/src/win32/reader.rs
+++ b/super_native_extensions/rust/src/win32/reader.rs
@@ -697,11 +697,7 @@ impl VirtualFileReader for StreamReader {
     }
 
     fn file_size(&self) -> NativeExtensionsResult<Option<i64>> {
-        let mut stat = STATSTG::default();
-        unsafe {
-            self.stream.Stat(&mut stat as *mut _, STATFLAG_NONAME)?;
-        }
-        Ok(Some(stat.cbSize as i64))
+        Ok(Some(self.length as i64))
     }
 
     fn file_name(&self) -> Option<String> {


### PR DESCRIPTION
We should never interact with the stream on main thread (it could deadlock when dealing with our virtual stream) and there already is cached length obtained when constructing `StreamReader`.