### PR TITLE
feat! implement custom drag snapshots

### DIFF
--- a/super_drag_and_drop/README.md
+++ b/super_drag_and_drop/README.md
@@ -83,12 +83,12 @@ class MyDraggableWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     // DragItemWidget provides the content for the drag (DragItem).
     return DragItemWidget(
-      dragItemProvider: (snapshot, session) async {
+      dragItemProvider: (request) async {
         // DragItem represents the content bein dragged.
         final item = DragItem(
           // snapshot() will return image snapshot of the DragItemWidget.
           // You can use any other drag image if your wish.
-          image: await snapshot(),
+          image: request.dragImage(),
           // This data is only accessible when dropping within same
           // application. (optional)
           localData: {'x': 3, 'y': 4},

--- a/super_drag_and_drop/example/lib/main.dart
+++ b/super_drag_and_drop/example/lib/main.dart
@@ -58,19 +58,18 @@ class DragableWidget extends StatefulWidget {
 class _DragableWidgetState extends State<DragableWidget> {
   bool _dragging = false;
 
-  Future<DragItem?> provideDragItem(
-      AsyncValueGetter<DragImage> snapshot, DragSession session) async {
-    final item = await widget.dragItemProvider(snapshot, session);
+  Future<DragItem?> provideDragItem(DragItemRequest request) async {
+    final item = await widget.dragItemProvider(request);
     if (item != null) {
       setState(() {
-        _dragging = session.dragging;
+        _dragging = request.session.dragging;
       });
-      session.dragStarted.addListener(() {
+      request.session.dragStarted.addListener(() {
         setState(() {
           _dragging = true;
         });
       });
-      session.dragCompleted.addListener(() {
+      request.session.dragCompleted.addListener(() {
         if (mounted) {
           setState(() {
             _dragging = false;
@@ -204,32 +203,26 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  Future<DragItem?> textDragItem(
-    AsyncValueGetter<DragImage> dragImage,
-    DragSession session,
-  ) async {
+  Future<DragItem?> textDragItem(DragItemRequest request) async {
     // For multi drag on iOS check if this item is already in the session
-    if (await session.hasLocalData('text-item')) {
+    if (await request.session.hasLocalData('text-item')) {
       return null;
     }
     final item = DragItem(
-        image: await dragImage(),
+        image: request.dragImage(),
         localData: 'text-item',
         suggestedName: 'PlainText.txt');
     item.add(Formats.plainText('Plain Text Value'));
     return item;
   }
 
-  Future<DragItem?> imageDragItem(
-    AsyncValueGetter<DragImage> dragImage,
-    DragSession session,
-  ) async {
+  Future<DragItem?> imageDragItem(DragItemRequest request) async {
     // For multi drag on iOS check if this item is already in the session
-    if (await session.hasLocalData('image-item')) {
+    if (await request.session.hasLocalData('image-item')) {
       return null;
     }
     final item = DragItem(
-      image: await dragImage(),
+      image: request.dragImage(),
       localData: 'image-item',
       suggestedName: 'Green.png',
     );
@@ -237,16 +230,13 @@ class _MyHomePageState extends State<MyHomePage> {
     return item;
   }
 
-  Future<DragItem?> lazyImageDragItem(
-    AsyncValueGetter<DragImage> dragImage,
-    DragSession session,
-  ) async {
+  Future<DragItem?> lazyImageDragItem(DragItemRequest request) async {
     // For multi drag on iOS check if this item is already in the session
-    if (await session.hasLocalData('lazy-image-item')) {
+    if (await request.session.hasLocalData('lazy-image-item')) {
       return null;
     }
     final item = DragItem(
-      image: await dragImage(),
+      image: await request.dragImage(),
       localData: 'lazy-image-item',
       suggestedName: 'LazyBlue.png',
     );
@@ -257,16 +247,13 @@ class _MyHomePageState extends State<MyHomePage> {
     return item;
   }
 
-  Future<DragItem?> virtualFileDragItem(
-    AsyncValueGetter<DragImage> dragImage,
-    DragSession session,
-  ) async {
+  Future<DragItem?> virtualFileDragItem(DragItemRequest request) async {
     // For multi drag on iOS check if this item is already in the session
-    if (await session.hasLocalData('virtual-file-item')) {
+    if (await request.session.hasLocalData('virtual-file-item')) {
       return null;
     }
     final item = DragItem(
-      image: await dragImage(),
+      image: request.dragImage(),
       localData: 'virtual-file-item',
       suggestedName: 'VirtualFile.txt',
     );
@@ -290,15 +277,13 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<DragItem?> multipleRepresentationsDragItem(
-    AsyncValueGetter<DragImage> dragImage,
-    DragSession session,
-  ) async {
+      DragItemRequest request) async {
     // For multi drag on iOS check if this item is already in the session
-    if (await session.hasLocalData('multiple-representations-item')) {
+    if (await request.session.hasLocalData('multiple-representations-item')) {
       return null;
     }
     final item = DragItem(
-      image: await dragImage(),
+      image: request.dragImage(),
       localData: 'multiple-representations-item',
     );
     item.add(Formats.png(await createImageData(Colors.pink)));

--- a/super_drag_and_drop/lib/src/base_draggable_widget.dart
+++ b/super_drag_and_drop/lib/src/base_draggable_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:super_native_extensions/widgets.dart';
 
 import 'drag_internal.dart';
 import 'draggable_widget.dart';
@@ -73,6 +74,23 @@ class BaseDraggableWidget extends StatelessWidget {
         child: child,
       );
     }
+    child = Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (_) {
+        Snapshotter.of(context)?.arm();
+      },
+      onPointerCancel: (_) {
+        if (context.mounted) {
+          Snapshotter.of(context)?.disarm();
+        }
+      },
+      onPointerUp: (_) {
+        if (context.mounted) {
+          Snapshotter.of(context)?.disarm();
+        }
+      },
+      child: child,
+    );
     return BaseDraggableRenderWidget(
       hitTestBehavior: hitTestBehavior,
       getDragConfiguration: dragConfiguration,

--- a/super_drag_and_drop/lib/src/base_draggable_widget.dart
+++ b/super_drag_and_drop/lib/src/base_draggable_widget.dart
@@ -77,16 +77,16 @@ class BaseDraggableWidget extends StatelessWidget {
     child = Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: (_) {
-        Snapshotter.of(context)?.arm();
+        Snapshotter.of(context)?.armed = true;
       },
       onPointerCancel: (_) {
         if (context.mounted) {
-          Snapshotter.of(context)?.disarm();
+          Snapshotter.of(context)?.armed = false;
         }
       },
       onPointerUp: (_) {
         if (context.mounted) {
-          Snapshotter.of(context)?.disarm();
+          Snapshotter.of(context)?.armed = false;
         }
       },
       child: child,

--- a/super_drag_and_drop/lib/src/drag_configuration.dart
+++ b/super_drag_and_drop/lib/src/drag_configuration.dart
@@ -1,27 +1,26 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:super_native_extensions/raw_drag_drop.dart' as raw;
 
-/// Image representation of single [DragItem].
 class DragImage {
-  DragImage(this.image, this.sourceRect);
+  DragImage({
+    required this.image,
+    this.liftImage,
+  });
 
-  /// Image to be used as drag image.
-  final ui.Image image;
+  /// Image used while dragging
+  raw.TargettedImage image;
 
-  /// Initial position of drag image (in global coordinates).
-  final ui.Rect sourceRect;
+  /// If specified this image will be used for lift animation on iOS.
+  raw.TargettedImage? liftImage;
 }
 
 /// Represent single item being dragged in a [DragSession].
 class DragItem extends DataWriterItem {
   DragItem({
     super.suggestedName,
-    this.liftImage,
     required this.image,
     this.localData,
   });
@@ -33,10 +32,6 @@ class DragItem extends DataWriterItem {
           defaultTargetPlatform == TargetPlatform.windows ||
           defaultTargetPlatform == TargetPlatform.iOS);
 
-  /// If specified this image will be used for lift animation on iOS.
-  final DragImage? liftImage;
-
-  /// Image used while dragging
   final DragImage image;
 
   /// Data associated with this drag item that can be only read when dropping

--- a/super_drag_and_drop/lib/src/drag_configuration.dart
+++ b/super_drag_and_drop/lib/src/drag_configuration.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:super_clipboard/super_clipboard.dart';
@@ -32,7 +34,7 @@ class DragItem extends DataWriterItem {
           defaultTargetPlatform == TargetPlatform.windows ||
           defaultTargetPlatform == TargetPlatform.iOS);
 
-  final DragImage image;
+  final FutureOr<DragImage> image;
 
   /// Data associated with this drag item that can be only read when dropping
   /// within same application. The data must be serializable with
@@ -45,7 +47,7 @@ class DragItem extends DataWriterItem {
 class DragOptions {
   const DragOptions({
     this.animatesToStartingPositionOnCancelOrFail = true,
-    this.prefersFullSizePreviews = false,
+    this.prefersFullSizePreviews = true,
   });
 
   /// macOS specific

--- a/super_drag_and_drop/lib/src/drag_internal.dart
+++ b/super_drag_and_drop/lib/src/drag_internal.dart
@@ -126,7 +126,11 @@ abstract class _DragDetector extends StatelessWidget {
     required this.child,
   });
 
-  Drag? maybeStartDrag(int? pointer, Offset position, double devicePixelRatio) {
+  Drag? maybeStartDrag(
+      int? pointer, Offset position_, double devicePixelRatio) {
+    final position = Offset(
+        (position_.dx * devicePixelRatio).roundToDouble() / devicePixelRatio,
+        (position_.dy * devicePixelRatio).roundToDouble() / devicePixelRatio);
     final dragContext = _dragContext;
     if (dragContext != null) {
       final session = dragContext.newSession(pointer: pointer);

--- a/super_drag_and_drop/lib/src/draggable_widget.dart
+++ b/super_drag_and_drop/lib/src/draggable_widget.dart
@@ -11,25 +11,42 @@ export 'package:super_native_extensions/raw_drag_drop.dart'
 import 'drag_configuration.dart';
 import 'base_draggable_widget.dart';
 
-typedef DragItemProvider = Future<DragItem?> Function(
+class DragItemRequest {
+  DragItemRequest({
+    required this.dragImage,
+    required this.location,
+    required this.session,
+  });
+
   /// Provides snapshot image of the containing [DragItemWidget].
-  AsyncValueGetter<DragImage> snapshot,
+  ///
+  /// If you want to customize the drag image you can wrap the [DragItemWidget]
+  /// in a [CustomSnapshotWidget].
+  ///
+  /// Note that using [dragImage] is optional, you can generate your own drag
+  /// image from scratch  when constructing [DragItem].
+  final Future<DragImage> Function() dragImage;
+
+  /// Drag location in global coordinates.
+  final Offset location;
 
   /// Current drag session.
-  raw.DragSession session,
-);
+  final raw.DragSession session;
+}
+
+typedef DragItemProvider = Future<DragItem?> Function(DragItemRequest);
 
 /// Widget that provides [DragItem] for a [DraggableWidget].
 ///
 /// Example usage
 /// ```dart
 /// DragItemWidget(
-///   dragItemProvider: (snapshot, session) async {
+///   dragItemProvider: (request) async {
 ///     // DragItem represents the content bein dragged.
 ///     final item = DragItem(
 ///       // snapshot() will return image snapshot of the DragItemWidget.
 ///       // You can use any other drag image if your wish.
-///       image: await snapshot(),
+///       image: request.dragImage(),
 ///       // This data is only accessible when dropping within same
 ///       // application. (optional)
 ///       localData: {'x': 3, 'y': 4},
@@ -79,33 +96,51 @@ class DragItemWidget extends StatefulWidget {
   State<StatefulWidget> createState() => DragItemWidgetState();
 }
 
-class DragItemWidgetState extends State<DragItemWidget> {
-  final repaintBoundary = GlobalKey();
+class _SnapshotException implements Exception {
+  _SnapshotException(this.message);
 
-  Future<DragImage> _getSnapshot() async {
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class DragItemWidgetState extends State<DragItemWidget> {
+  Future<DragImage> _getSnapshot(Offset location) async {
     final snapshotter = Snapshotter.of(_innerContext!)!;
-    final dragSnapshot = await snapshotter.getSnapshot(SnapshotType.drag);
-    final snapshot = dragSnapshot ?? await snapshotter.getSnapshot(null);
+    final dragSnapshot =
+        await snapshotter.getSnapshot(location, SnapshotType.drag);
+    final snapshot =
+        dragSnapshot ?? await snapshotter.getSnapshot(location, null);
 
     if (snapshot == null) {
       // This might happen if widget is removed before snapshot is ready.
       // TODO(knopp): Handle this better.
-      throw StateError('Failed get drag snapshot.');
+      throw _SnapshotException('Failed get drag snapshot.');
     }
     raw.TargettedImage? liftImage;
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      liftImage = await snapshotter.getSnapshot(SnapshotType.lift);
+      liftImage = await snapshotter.getSnapshot(location, SnapshotType.lift);
       // If there is no custom lift image but custom drag snapshot, use
       // default image as lift image for smoother transition.
       if (liftImage == null && dragSnapshot != null) {
-        liftImage = await snapshotter.getSnapshot(null);
+        liftImage = await snapshotter.getSnapshot(location, null);
       }
     }
     return DragImage(image: snapshot, liftImage: liftImage);
   }
 
-  Future<DragItem?> createItem(raw.DragSession session) async {
-    return widget.dragItemProvider(_getSnapshot, session);
+  Future<DragItem?> createItem(Offset location, raw.DragSession session) async {
+    final request = DragItemRequest(
+      dragImage: () => _getSnapshot(location),
+      location: location,
+      session: session,
+    );
+    try {
+      return widget.dragItemProvider(request);
+    } on _SnapshotException {
+      return null;
+    }
   }
 
   Future<List<raw.DropOperation>> getAllowedOperations() async {
@@ -180,7 +215,9 @@ class DraggableWidget extends StatelessWidget {
   }
 
   Future<DragConfiguration?> dragConfigurationForItems(
-      List<DragItemWidgetState> items, raw.DragSession session) async {
+      List<DragItemWidgetState> items,
+      Offset location,
+      raw.DragSession session) async {
     List<raw.DropOperation>? allowedOperations;
     for (final item in items) {
       if (allowedOperations == null) {
@@ -195,7 +232,7 @@ class DraggableWidget extends StatelessWidget {
     if (allowedOperations?.isNotEmpty == true) {
       final dragItems = <DragItem>[];
       for (final item in items) {
-        final dragItem = await item.createItem(session);
+        final dragItem = await item.createItem(location, session);
         if (dragItem != null) {
           dragItems.add(dragItem);
         }
@@ -213,12 +250,12 @@ class DraggableWidget extends StatelessWidget {
     return null;
   }
 
-  Future<List<DragItem>?> additionalItems(
-      List<DragItemWidgetState> items, raw.DragSession session) async {
+  Future<List<DragItem>?> additionalItems(List<DragItemWidgetState> items,
+      Offset location, raw.DragSession session) async {
     final dragItems = <DragItem>[];
     for (final item in items) {
       if (item.widget.canAddItemToExistingSession) {
-        final dragItem = await item.createItem(session);
+        final dragItem = await item.createItem(location, session);
         if (dragItem != null) {
           dragItems.add(dragItem);
         }
@@ -241,13 +278,13 @@ class DraggableWidget extends StatelessWidget {
       isLocationDraggable: isLocationDraggable,
       hitTestBehavior: hitTestBehavior,
       child: child,
-      dragConfiguration: (_, session) async {
+      dragConfiguration: (location, session) async {
         final items = dragItemsProvider(context);
-        return dragConfigurationForItems(items, session);
+        return dragConfigurationForItems(items, location, session);
       },
-      additionalItems: (_, session) async {
+      additionalItems: (location, session) async {
         final items = additionalDragItemsProvider(context);
-        return additionalItems(items, session);
+        return additionalItems(items, location, session);
       },
     );
   }

--- a/super_drag_and_drop/lib/src/into_raw.dart
+++ b/super_drag_and_drop/lib/src/into_raw.dart
@@ -28,9 +28,12 @@ extension DragItemsIntoRaw on List<DragItem> {
     }
     final items = <raw.DragItem>[];
     for (final item in indexed()) {
+      final image = item.value.image is Future
+          ? await item.value.image
+          : item.value.image as DragImage;
       items.add(raw.DragItem(
         dataProvider: handles[item.index],
-        image: await item.value.image.intoRaw(devicePixelRatio),
+        image: await image.intoRaw(devicePixelRatio),
         localData: item.value.localData,
       ));
     }

--- a/super_drag_and_drop/lib/src/into_raw.dart
+++ b/super_drag_and_drop/lib/src/into_raw.dart
@@ -6,11 +6,10 @@ import 'drag_configuration.dart';
 import 'indexed.dart';
 
 extension DragImageIntoRaw on DragImage {
-  Future<raw.DragImage> intoRaw(double devicePixelRatio) async {
-    return raw.DragImage(
-      imageData: await raw.ImageData.fromImage(image,
-          devicePixelRatio: devicePixelRatio),
-      sourceRect: sourceRect,
+  Future<raw.DragImageData> intoRaw(double devicePixelRatio) async {
+    return raw.DragImageData(
+      image: await image.intoRaw(devicePixelRatio),
+      liftImage: await liftImage?.intoRaw(devicePixelRatio),
     );
   }
 }
@@ -31,7 +30,6 @@ extension DragItemsIntoRaw on List<DragItem> {
     for (final item in indexed()) {
       items.add(raw.DragItem(
         dataProvider: handles[item.index],
-        liftImage: await item.value.liftImage?.intoRaw(devicePixelRatio),
         image: await item.value.image.intoRaw(devicePixelRatio),
         localData: item.value.localData,
       ));

--- a/super_drag_and_drop/lib/super_drag_and_drop.dart
+++ b/super_drag_and_drop/lib/super_drag_and_drop.dart
@@ -3,7 +3,12 @@ library super_drag_and_drop;
 export 'package:super_clipboard/src/format.dart';
 export 'package:super_clipboard/src/standard_formats.dart';
 export 'package:super_native_extensions/widgets.dart'
-    hide FallbackSnapshotWidget;
+    show
+        CustomSnapshotWidget,
+        SnapshotType,
+        SnapshotBuilder,
+        ConstraintsTransformProvider,
+        TranslationProvider;
 export 'package:super_native_extensions/src/api_model.dart' show TargettedImage;
 
 export 'src/drag_configuration.dart';

--- a/super_drag_and_drop/lib/super_drag_and_drop.dart
+++ b/super_drag_and_drop/lib/super_drag_and_drop.dart
@@ -2,6 +2,9 @@ library super_drag_and_drop;
 
 export 'package:super_clipboard/src/format.dart';
 export 'package:super_clipboard/src/standard_formats.dart';
+export 'package:super_native_extensions/widgets.dart'
+    hide FallbackSnapshotWidget;
+export 'package:super_native_extensions/src/api_model.dart' show TargettedImage;
 
 export 'src/drag_configuration.dart';
 export 'src/base_draggable_widget.dart';

--- a/super_keyboard_layout/example/pubspec.lock
+++ b/super_keyboard_layout/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -211,14 +211,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0+3"
+    version: "0.2.1+1"
   super_native_extensions:
     dependency: "direct overridden"
     description:
       path: "../../super_native_extensions"
       relative: true
     source: path
-    version: "0.2.2+1"
+    version: "0.2.4"
   term_glyph:
     dependency: transitive
     description:

--- a/super_native_extensions/lib/src/api_model.dart
+++ b/super_native_extensions/lib/src/api_model.dart
@@ -33,6 +33,37 @@ class ImageData {
   }
 }
 
+/// Image representation of part of user interface.
+class TargettedImage {
+  TargettedImage(this.image, this.rect);
+
+  /// Image to be used as avatar image.
+  final Image image;
+
+  /// Initial position of avatar image (in global coordinates).
+  final Rect rect;
+}
+
+class TargettedImageData {
+  TargettedImageData({
+    required this.imageData,
+    required this.rect,
+  });
+
+  final ImageData imageData;
+  final Rect rect;
+}
+
+extension TargettedImageIntoRaw on TargettedImage {
+  Future<TargettedImageData> intoRaw(double devicePixelRatio) async {
+    return TargettedImageData(
+      imageData:
+          await ImageData.fromImage(image, devicePixelRatio: devicePixelRatio),
+      rect: rect,
+    );
+  }
+}
+
 //
 // Drag
 //

--- a/super_native_extensions/lib/src/drag.dart
+++ b/super_native_extensions/lib/src/drag.dart
@@ -26,33 +26,31 @@ class DragConfiguration {
   final bool prefersFullSizePreviews;
 }
 
+class DragImageData {
+  DragImageData({
+    required this.image,
+    this.liftImage,
+  });
+
+  /// Image used while dragging.
+  TargettedImageData image;
+
+  /// Used on iPad during lift (before dragging starts). If not set normal
+  /// drag image is used. This should closely resemble the widget being dragged.
+  TargettedImageData? liftImage;
+}
+
 class DragItem {
   DragItem({
     required this.dataProvider,
-    this.liftImage,
     required this.image,
     this.localData,
   });
 
   final DataProviderHandle dataProvider;
 
-  /// Used on iPad during lift (before dragging starts). If not set normal
-  /// drag image is used. This should closely resemble the widget being dragged.
-  final DragImage? liftImage;
-
-  /// Image used while dragging.
-  final DragImage image;
+  final DragImageData image;
   final Object? localData;
-}
-
-class DragImage {
-  DragImage({
-    required this.imageData,
-    required this.sourceRect,
-  });
-
-  final ImageData imageData;
-  final ui.Rect sourceRect;
 }
 
 class DragRequest {
@@ -64,7 +62,7 @@ class DragRequest {
 
   final DragConfiguration configuration;
   final ui.Offset position;
-  final DragImage? combinedDragImage;
+  final TargettedImageData? combinedDragImage;
 }
 
 /// Represents a drag session. Allows inspecting local drag data and

--- a/super_native_extensions/lib/src/drag_internal.dart
+++ b/super_native_extensions/lib/src/drag_internal.dart
@@ -5,26 +5,28 @@ import 'package:collection/collection.dart';
 import 'api_model.dart';
 import 'drag.dart';
 
-Future<DragImage> combineDragImage(DragConfiguration configuration) async {
+Future<TargettedImageData> combineDragImage(
+    DragConfiguration configuration) async {
   var combinedRect = Rect.zero;
   for (final item in configuration.items) {
     if (combinedRect.isEmpty) {
-      combinedRect = item.image.sourceRect;
+      combinedRect = item.image.image.rect;
     } else {
-      combinedRect = combinedRect.expandToInclude(item.image.sourceRect);
+      combinedRect = combinedRect.expandToInclude(item.image.image.rect);
     }
   }
   final scale =
-      configuration.items.firstOrNull?.image.imageData.devicePixelRatio ?? 1.0;
+      configuration.items.firstOrNull?.image.image.imageData.devicePixelRatio ??
+          1.0;
   final offset = combinedRect.topLeft;
   final rect = combinedRect.translate(-offset.dx, -offset.dy);
   final recorder = PictureRecorder();
   final canvas = Canvas(recorder);
   canvas.scale(scale, scale);
   for (final item in configuration.items) {
-    final image = item.image.imageData.sourceImage;
+    final image = item.image.image.imageData.sourceImage;
     final destinationRect =
-        item.image.sourceRect.translate(-offset.dx, -offset.dy);
+        item.image.image.rect.translate(-offset.dx, -offset.dy);
     canvas.drawImageRect(
         image,
         Rect.fromLTWH(0, 0, image.width.toDouble(), image.height.toDouble()),
@@ -35,8 +37,8 @@ Future<DragImage> combineDragImage(DragConfiguration configuration) async {
   final image = await picture.toImage(
       (rect.width * scale).ceil(), (rect.height * scale).ceil());
 
-  return DragImage(
+  return TargettedImageData(
     imageData: await ImageData.fromImage(image, devicePixelRatio: scale),
-    sourceRect: combinedRect,
+    rect: combinedRect,
   );
 }

--- a/super_native_extensions/lib/src/native/drag.dart
+++ b/super_native_extensions/lib/src/native/drag.dart
@@ -28,15 +28,15 @@ extension DragItemExt on DragItem {
   dynamic serialize() => {
         'dataProviderId': dataProvider.id,
         'localData': localData,
-        'image': image.serialize(),
-        'liftImage': liftImage?.serialize(),
+        'image': image.image.serialize(),
+        'liftImage': image.liftImage?.serialize(),
       };
 }
 
-extension DragImageExt on DragImage {
+extension DragImageExt on TargettedImageData {
   dynamic serialize() => {
         'imageData': imageData.serialize(),
-        'sourceRect': sourceRect.serialize(),
+        'sourceRect': rect.serialize(),
       };
 }
 

--- a/super_native_extensions/lib/src/web/drag.dart
+++ b/super_native_extensions/lib/src/web/drag.dart
@@ -78,7 +78,7 @@ class DragSessionImpl extends DragSession implements DragDriverDelegate {
 
 class _SessionState implements DragDriverDelegate {
   final DragConfiguration configuration;
-  final DragImage image;
+  final TargettedImageData image;
   final Offset originalPosition;
   final html.CanvasElement canvas;
   final ValueNotifier<Offset?> lastScreenLocation;
@@ -129,11 +129,11 @@ class _SessionState implements DragDriverDelegate {
 
   void _moveCanvas(Offset position) {
     canvas.style.left =
-        '${image.sourceRect.left + position.dx - originalPosition.dx}px';
+        '${image.rect.left + position.dx - originalPosition.dx}px';
     canvas.style.top =
-        '${image.sourceRect.top + position.dy - originalPosition.dy}px';
-    canvas.style.width = '${image.sourceRect.width}px';
-    canvas.style.height = '${image.sourceRect.height}px';
+        '${image.rect.top + position.dy - originalPosition.dy}px';
+    canvas.style.width = '${image.rect.width}px';
+    canvas.style.height = '${image.rect.height}px';
   }
 
   void updatePosition(Offset position) async {

--- a/super_native_extensions/lib/src/widgets/snapshot.dart
+++ b/super_native_extensions/lib/src/widgets/snapshot.dart
@@ -1,0 +1,284 @@
+import 'dart:async';
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import '../api_model.dart';
+
+enum SnapshotType {
+  lift,
+  drag,
+}
+
+typedef SnapshotBuilder = Widget Function(
+  BuildContext context,
+  SnapshotType? type,
+);
+
+class CustomSnapshotWidget extends StatefulWidget {
+  const CustomSnapshotWidget({
+    super.key,
+    required this.builder,
+    this.supportedTypes = const {},
+  });
+
+  final Set<SnapshotType> supportedTypes;
+  final SnapshotBuilder builder;
+
+  @override
+  State<CustomSnapshotWidget> createState() => _CustomSnapshotWidgetState();
+}
+
+abstract class Snapshotter {
+  static Snapshotter? of(BuildContext context) {
+    final real = context.findAncestorStateOfType<_CustomSnapshotWidgetState>();
+    if (real != null) {
+      return real;
+    } else {
+      return context.findAncestorStateOfType<_FallbackSnapshotWidgetState>();
+    }
+  }
+
+  void arm();
+  void disarm();
+
+  Future<TargettedImage?> getSnapshot(SnapshotType? type);
+}
+
+class _PendingSnapshot {
+  _PendingSnapshot(this.type, this.completer);
+
+  final SnapshotType? type;
+  final Completer<TargettedImage?> completer;
+}
+
+TargettedImage _getSnapshot(
+    BuildContext context, RenderRepaintBoundary renderObject) {
+  final image = renderObject.toImageSync(
+      pixelRatio: MediaQuery.of(context).devicePixelRatio);
+  final transform = renderObject.getTransformTo(null);
+  final r =
+      Rect.fromLTWH(0, 0, renderObject.size.width, renderObject.size.height);
+  final rect = MatrixUtils.transformRect(transform, r);
+  return TargettedImage(image, rect);
+}
+
+class _ZeroClipper extends CustomClipper<Rect> {
+  const _ZeroClipper();
+
+  @override
+  Rect getClip(Size size) {
+    return Rect.zero;
+  }
+
+  @override
+  bool shouldReclip(covariant CustomClipper<Rect> oldClipper) {
+    return false;
+  }
+}
+
+class _CustomSnapshotWidgetState extends State<CustomSnapshotWidget>
+    implements Snapshotter {
+  @override
+  Widget build(BuildContext context) {
+    return Builder(builder: (context) {
+      if (!_armed && _pendingSnapshots.isEmpty) {
+        return KeyedSubtree(
+          key: _contentKey,
+          child: widget.builder(context, null),
+        );
+      } else {
+        return Stack(
+          fit: StackFit.passthrough,
+          children: [
+            RepaintBoundary(
+              key: _defaultKey,
+              child: KeyedSubtree(
+                key: _contentKey,
+                child: widget.builder(context, null),
+              ),
+            ),
+            for (final type in widget.supportedTypes)
+              IgnorePointer(
+                ignoring: true,
+                child: ClipRect(
+                  clipper: const _ZeroClipper(),
+                  child: RepaintBoundary(
+                    key: _keys[type],
+                    child: widget.builder(context, type),
+                  ),
+                ),
+              ),
+          ],
+        );
+      }
+    });
+  }
+
+  bool _armed = false;
+  final _pendingSnapshots = <_PendingSnapshot>[];
+
+  final _contentKey = GlobalKey();
+
+  final _defaultKey = GlobalKey();
+
+  final _keys = {
+    SnapshotType.lift: GlobalKey(),
+    SnapshotType.drag: GlobalKey(),
+  };
+
+  RenderRepaintBoundary? _getRenderObject(SnapshotType? type) {
+    final object = type != null
+        ? _keys[type]?.currentContext?.findRenderObject()
+        : _defaultKey.currentContext?.findRenderObject();
+    return object is RenderRepaintBoundary ? object : null;
+  }
+
+  @override
+  void arm() {
+    if (!_armed) {
+      setState(() {
+        _armed = true;
+      });
+    }
+  }
+
+  @override
+  void disarm() {
+    if (_armed) {
+      setState(() {
+        _armed = false;
+      });
+    }
+  }
+
+  void _checkSnapshots() {
+    if (_pendingSnapshots.isEmpty) {
+      return;
+    }
+    if (!mounted) {
+      for (final snapshot in _pendingSnapshots) {
+        snapshot.completer.complete(null);
+      }
+      _pendingSnapshots.clear();
+      return;
+    }
+    if (_getRenderObject(null) == null) {
+      setState(() {});
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        _checkSnapshots();
+      });
+      return;
+    }
+
+    for (final s in _pendingSnapshots) {
+      final renderObject = _getRenderObject(s.type);
+      if (renderObject != null) {
+        s.completer.complete(_getSnapshot(context, renderObject));
+      } else {
+        s.completer.complete(null);
+      }
+    }
+    _pendingSnapshots.clear();
+    setState(() {});
+  }
+
+  @override
+  Future<TargettedImage?> getSnapshot(SnapshotType? type) {
+    final completer = Completer<TargettedImage?>();
+    _pendingSnapshots.add(_PendingSnapshot(type, completer));
+    _checkSnapshots();
+    return completer.future;
+  }
+}
+
+class FallbackSnapshotWidget extends StatefulWidget {
+  const FallbackSnapshotWidget({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  State<FallbackSnapshotWidget> createState() => _FallbackSnapshotWidgetState();
+}
+
+class _FallbackSnapshotWidgetState extends State<FallbackSnapshotWidget>
+    implements Snapshotter {
+  final _contentKey = GlobalKey();
+  final _repaintBoundaryKey = GlobalKey();
+
+  final _pendingSnapshots = <Completer<TargettedImage?>>[];
+
+  bool _armed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_armed && _pendingSnapshots.isEmpty) {
+      return KeyedSubtree(key: _contentKey, child: widget.child);
+    }
+    if (_armed || _pendingSnapshots.isNotEmpty) {
+      return RepaintBoundary(
+        key: _repaintBoundaryKey,
+        child: KeyedSubtree(key: _contentKey, child: widget.child),
+      );
+    } else {
+      return KeyedSubtree(key: _contentKey, child: widget.child);
+    }
+  }
+
+  @override
+  Future<TargettedImage?> getSnapshot(SnapshotType? type) {
+    if (type != null) {
+      return Future.value(null);
+    }
+
+    final completer = Completer<TargettedImage>();
+    _pendingSnapshots.add(completer);
+    _checkSnapshot();
+    return completer.future;
+  }
+
+  void _checkSnapshot() {
+    if (!mounted) {
+      for (final completer in _pendingSnapshots) {
+        completer.complete(null);
+      }
+      _pendingSnapshots.clear();
+      return;
+    }
+    final object = _repaintBoundaryKey.currentContext?.findRenderObject();
+    if (object is RenderRepaintBoundary) {
+      final snapshot = _getSnapshot(context, object);
+      for (final completer in _pendingSnapshots) {
+        completer.complete(snapshot);
+      }
+      _pendingSnapshots.clear();
+      setState(() {});
+    } else {
+      setState(() {});
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        _checkSnapshot();
+      });
+    }
+  }
+
+  @override
+  void arm() {
+    if (!_armed) {
+      setState(() {
+        _armed = true;
+      });
+    }
+  }
+
+  @override
+  void disarm() {
+    if (_armed) {
+      setState(() {
+        _armed = false;
+      });
+    }
+  }
+}

--- a/super_native_extensions/lib/src/widgets/snapshot.dart
+++ b/super_native_extensions/lib/src/widgets/snapshot.dart
@@ -332,7 +332,7 @@ class _FallbackSnapshotWidgetState extends State<FallbackSnapshotWidget>
 }
 
 class _SnapshotLayout extends MultiChildRenderObjectWidget {
-  const _SnapshotLayout({
+  _SnapshotLayout({
     // ignore: unused_element
     super.key,
     required super.children,

--- a/super_native_extensions/lib/widgets.dart
+++ b/super_native_extensions/lib/widgets.dart
@@ -3,5 +3,7 @@ export 'src/widgets/snapshot.dart'
         CustomSnapshotWidget,
         SnapshotType,
         SnapshotBuilder,
+        ConstraintsTransformProvider,
+        TranslationProvider,
         FallbackSnapshotWidget,
         Snapshotter;

--- a/super_native_extensions/lib/widgets.dart
+++ b/super_native_extensions/lib/widgets.dart
@@ -1,0 +1,7 @@
+export 'src/widgets/snapshot.dart'
+    show
+        CustomSnapshotWidget,
+        SnapshotType,
+        SnapshotBuilder,
+        FallbackSnapshotWidget,
+        Snapshotter;

--- a/super_native_extensions/rust/src/darwin/ios/drag.rs
+++ b/super_native_extensions/rust/src/darwin/ios/drag.rs
@@ -231,9 +231,18 @@ impl Session {
                     let (index, _) = PlatformDragContext::item_info(item);
                     let image = self.image_view_for_item(index, ImageType::Drag);
                     let provider = ConcreteBlock::new(move || {
+                        let parameters: id = msg_send![class!(UIDragPreviewParameters), new];
+                        let () = msg_send![parameters, autorelease];
+                        let clear_color: id = msg_send![class!(UIColor), clearColor];
+                        let () = msg_send![parameters, setBackgroundColor: clear_color];
+
+                        // TODO(knopp): Make this configurable
+                        let shadow_path: id = msg_send![class!(UIBezierPath), bezierPathWithRect: CGRect{ origin: CGPoint { x: 0.0, y: 0.0 }, size: CGSize { width: 0.0, height: 0.0,} }];
+                        let () = msg_send![parameters, setShadowPath: shadow_path];
+
                         let image = image.clone().autorelease();
                         let preview: id = msg_send![class!(UIDragPreview), alloc];
-                        let () = msg_send![preview, initWithView: image];
+                        let () = msg_send![preview, initWithView:image parameters: parameters];
                         let () = msg_send![preview, autorelease];
                         preview
                     });

--- a/super_native_extensions/rust/src/win32/reader.rs
+++ b/super_native_extensions/rust/src/win32/reader.rs
@@ -582,7 +582,7 @@ impl PlatformDataReader {
                 completer,
             );
             ReleaseStgMedium(&mut medium as *mut STGMEDIUM);
-            return future.await;
+            future.await
         }
     }
 }


### PR DESCRIPTION
This PR introduces `CustomSnapshotWidget` to simplify providing custom drag snapshots.

This is a **breaking change**:

```dart
    return DragItemWidget(
      dragItemProvider: (snapshot, session) async {
        final item = DragItem(
          image: await snapshot(),        
          localData: {'x': 3, 'y': 4},
        );
```
 becomes
```dart
    return DragItemWidget(
      dragItemProvider: (request) async {
        final item = DragItem(
          image: request.dragImage(),
          localData: {'x': 3, 'y': 4},
        );
```

To be able to build widget for custom drag avatars wrap `DragItemWidget` inside a `CustomSnapshotWidget`:

```dart
    return CustomSnapshotWidget(
      builder: (context, type) {
        return DragItemWidget(
          allowedOperations: () => [DropOperation.copy],
          canAddItemToExistingSession: true,
          dragItemProvider: provideDragItem,
          child: Container(
              // Red background for drag avatar, blue otherwise
             color: type == SnapshotType.drag ? Colors.red : Colors.blue,
             child: ...
```