### PR TITLE
Use force loading instead of manual symbols on iOS and macOS

### DIFF
--- a/super_native_extensions/ios/super_native_extensions.podspec
+++ b/super_native_extensions/ios/super_native_extensions.podspec
@@ -30,7 +30,7 @@ A new Flutter plugin project.
     # Flutter.framework does not contain a i386 slice.
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     # Rust can't produce armv7 and it's being removed from Flutter as well
-    'EXCLUDED_ARCHS' => 'armv7',\
+    'EXCLUDED_ARCHS' => 'armv7',
     # We use `-force_load` instead of `-l` since Xcode strips out unused symbols from static libraries.
     'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libsuper_native_extensions.a -framework CoreServices',
   }

--- a/super_native_extensions/ios/super_native_extensions.podspec
+++ b/super_native_extensions/ios/super_native_extensions.podspec
@@ -30,10 +30,9 @@ A new Flutter plugin project.
     # Flutter.framework does not contain a i386 slice.
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     # Rust can't produce armv7 and it's being removed from Flutter as well
-    'EXCLUDED_ARCHS' => 'armv7',
-    # For static lib we need better control of re-exported symbols
-    'EXPORTED_SYMBOLS_FILE' => '$PODS_TARGET_SRCROOT/../rust/symbols.txt',
-    'OTHER_LDFLAGS' => '-lsuper_native_extensions -framework CoreServices',
+    'EXCLUDED_ARCHS' => 'armv7',\
+    # We use `-force_load` instead of `-l` since Xcode strips out unused symbols from static libraries.
+    'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libsuper_native_extensions.a -framework CoreServices',
   }
   s.user_target_xcconfig = {
     'EXCLUDED_ARCHS' => 'armv7',

--- a/super_native_extensions/macos/super_native_extensions.podspec
+++ b/super_native_extensions/macos/super_native_extensions.podspec
@@ -31,9 +31,8 @@ A new Flutter plugin project.
   }
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    # For static lib we need better control of re-exported symbols
-    'EXPORTED_SYMBOLS_FILE' => '$PODS_TARGET_SRCROOT/../rust/symbols.txt',
-    'OTHER_LDFLAGS' => '-lsuper_native_extensions',
+    # We use `-force_load` instead of `-l` since Xcode strips out unused symbols from static libraries.
+    'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libsuper_native_extensions.a',
     'DEAD_CODE_STRIPPING' => 'YES',
     'STRIP_INSTALLED_PRODUCT[config=Release][sdk=*][arch=*]' => "YES",
     'STRIP_STYLE[config=Release][sdk=*][arch=*]' => "non-global",

--- a/super_native_extensions/rust/symbols.txt
+++ b/super_native_extensions/rust/symbols.txt
@@ -1,4 +1,0 @@
-_OBJC_CLASS_$_SuperNativeExtensionsPlugin
-_super_native_extensions_init_message_channel_context
-_super_native_extensions_stream_write
-_super_native_extensions_stream_close


### PR DESCRIPTION
```
_OBJC_CLASS_$_SuperNativeExtensionsPlugin
_super_native_extensions_init_message_channel_context
_super_native_extensions_stream_write
_super_native_extensions_stream_close
```
This is the content of `super_native_extensions/rust/symbols.txt`. Though this might work on some architectures, I encountered some build errors when running on x86_64 macOS. On this X86_64 macOS platform, additional symbols were needed, which were very long and weird that it seemed almost impossible to write all symbols that would be needed on different architectures. Also, they make conflicts across architectures if they are written in the same file.

IMO, it would be much better if we just force-load the static library file, including all the symbols already declared.