### PR TITLE
Add .csv file format

### DIFF
--- a/super_clipboard/lib/src/standard_formats.dart
+++ b/super_clipboard/lib/src/standard_formats.dart
@@ -50,6 +50,7 @@ class Formats {
     pdf,
     doc,
     docx,
+    csv,
     xls,
     xlsx,
     ppt,
@@ -378,6 +379,11 @@ class Formats {
     mimeTypes: [
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     ],
+  );
+
+  static const csv = SimpleFileFormat(
+    uniformTypeIdentifiers: ['public.comma-separated-values-text'],
+    mimeTypes: ['text/csv'],
   );
 
   static const xls = SimpleFileFormat(


### PR DESCRIPTION
What was done:
- Add `CSV ` file format to standard_formats.dart
- Got uniformTypeIdentifiers `public.comma-separated-values-text` from [Apple docs ](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype/3551477-commaseparatedtext)
- Got mime type `text/csv` from this [memo](https://datatracker.ietf.org/doc/html/rfc4180#page-1)

How was it tested:
- Needed it for [super drag and drop](https://pub.dev/packages/super_drag_and_drop) package on web platform, so only tested on web so far

Please let me know if any changes are needed.