### PR TITLE
feat! Implement HotKey.onReleased

### DIFF
--- a/super_hot_key/lib/super_hot_key.dart
+++ b/super_hot_key/lib/super_hot_key.dart
@@ -39,12 +39,12 @@ class HotKeyDefinition {
 class HotKey {
   final int _handle;
   final HotKeyDefinition definition;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
   final VoidCallback? onReleased;
 
   static Future<HotKey?> create({
     required HotKeyDefinition definition,
-    required VoidCallback onPressed,
+    required VoidCallback? onPressed,
     required VoidCallback? onReleased,
   }) async {
     return _HotKeyManager.instance.createHotKey(
@@ -78,7 +78,7 @@ class _HotKeyManager extends raw.HotKeyManagerDelegate {
 
   Future<HotKey?> createHotKey(
     HotKeyDefinition definition,
-    VoidCallback onPressed,
+    VoidCallback? onPressed,
     VoidCallback? onReleased,
   ) async {
     final rawDefinition = await definition.toRaw();
@@ -107,7 +107,7 @@ class _HotKeyManager extends raw.HotKeyManagerDelegate {
 
   @override
   void onHotKeyPressed(int handle) {
-    _hotKeys[handle]?.onPressed();
+    _hotKeys[handle]?.onPressed?.call();
   }
 
   @override

--- a/super_native_extensions/lib/src/hot_key.dart
+++ b/super_native_extensions/lib/src/hot_key.dart
@@ -26,7 +26,8 @@ class HotKeyDefinition {
 
 abstract class HotKeyManagerDelegate {
   /// Invoked when hot key with given handle is pressed.
-  void onHotKey(int handle);
+  void onHotKeyPressed(int handle);
+  void onHotKeyReleased(int handle);
 }
 
 abstract class HotKeyManager {

--- a/super_native_extensions/lib/src/native/hot_key.dart
+++ b/super_native_extensions/lib/src/native/hot_key.dart
@@ -10,8 +10,10 @@ class HotKeyManagerImpl extends HotKeyManager {
   }
 
   Future<dynamic> _onMethodCall(MethodCall call) async {
-    if (call.method == 'onHotKey') {
-      _delegate?.onHotKey(call.arguments as int);
+    if (call.method == 'onHotKeyPressed') {
+      _delegate?.onHotKeyPressed(call.arguments as int);
+    } else if (call.method == 'onHotKeyReleased') {
+      _delegate?.onHotKeyReleased(call.arguments as int);
     }
   }
 

--- a/super_native_extensions/rust/src/darwin/macos/hot_key_sys.rs
+++ b/super_native_extensions/rust/src/darwin/macos/hot_key_sys.rs
@@ -26,6 +26,8 @@ pub struct EventTypeSpec {
 pub const kEventClassKeyboard: OSType = 1801812322;
 #[allow(non_upper_case_globals)]
 pub const kEventHotKeyPressed: u32 = 5;
+#[allow(non_upper_case_globals)]
+pub const kEventHotKeyReleased: u32 = 6;
 extern "C" {
     pub fn InstallEventHandler(
         inTarget: EventTargetRef,
@@ -56,6 +58,9 @@ extern "C" {
         outActualSize: *mut ByteCount,
         outData: *mut ::std::os::raw::c_void,
     ) -> OSStatus;
+}
+extern "C" {
+    pub fn GetEventKind(inEvent: EventRef) -> u32;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/super_native_extensions/rust/src/hot_key_manager.rs
+++ b/super_native_extensions/rust/src/hot_key_manager.rs
@@ -45,6 +45,7 @@ pub struct HotKeyManager {
 
 pub trait HotKeyManagerDelegate {
     fn on_hot_key_pressed(&self, handle: HotKeyHandle);
+    fn on_hot_key_released(&self, handle: HotKeyHandle);
 }
 
 pub trait GetHotKeyManager {
@@ -137,9 +138,20 @@ impl HotKeyManagerDelegate for HotKeyManager {
         let handle_to_isolate = self.handle_to_isolate.borrow();
         let isolate = handle_to_isolate.get(&handle);
         if let Some(isolate) = isolate {
-            self.invoker.call_method(*isolate, "onHotKey", handle, |r| {
-                r.ok_log();
-            });
+            self.invoker
+                .call_method(*isolate, "onHotKeyPressed", handle, |r| {
+                    r.ok_log();
+                });
+        }
+    }
+    fn on_hot_key_released(&self, handle: HotKeyHandle) {
+        let handle_to_isolate = self.handle_to_isolate.borrow();
+        let isolate = handle_to_isolate.get(&handle);
+        if let Some(isolate) = isolate {
+            self.invoker
+                .call_method(*isolate, "onHotKeyReleased", handle, |r| {
+                    r.ok_log();
+                });
         }
     }
 }

--- a/super_native_extensions/rust/src/hot_key_manager.rs
+++ b/super_native_extensions/rust/src/hot_key_manager.rs
@@ -18,7 +18,7 @@ use crate::{
     util::NextId,
 };
 
-#[derive(TryFromValue, Debug)]
+#[derive(TryFromValue, Debug, Clone)]
 #[irondash(rename_all = "camelCase")]
 pub struct HotKeyCreateRequest {
     pub alt: bool,

--- a/super_native_extensions/rust/src/win32/hot_key.rs
+++ b/super_native_extensions/rust/src/win32/hot_key.rs
@@ -1,7 +1,8 @@
 use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
-    rc::Weak,
+    rc::{Rc, Weak},
+    time::Duration,
 };
 
 use irondash_message_channel::Late;
@@ -10,8 +11,9 @@ use windows::Win32::{
     Foundation::HWND,
     UI::{
         Input::KeyboardAndMouse::{
-            MapVirtualKeyW, RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MAPVK_VSC_TO_VK,
-            MOD_ALT, MOD_CONTROL, MOD_SHIFT, MOD_WIN,
+            GetAsyncKeyState, GetKeyState, MapVirtualKeyW, RegisterHotKey, UnregisterHotKey,
+            HOT_KEY_MODIFIERS, MAPVK_VSC_TO_VK, MOD_ALT, MOD_CONTROL, MOD_NOREPEAT, MOD_SHIFT,
+            MOD_WIN,
         },
         WindowsAndMessaging::WM_HOTKEY,
     },
@@ -25,7 +27,7 @@ use crate::{
 pub struct PlatformHotKeyManager {
     delegate: Weak<dyn HotKeyManagerDelegate>,
     next_id: Cell<i32>,
-    hot_keys: RefCell<HashMap<i32, HotKeyHandle>>,
+    hot_keys: RefCell<HashMap<i32, (HotKeyHandle, HotKeyCreateRequest)>>,
     weak_self: Late<Weak<Self>>,
 }
 
@@ -68,20 +70,24 @@ impl PlatformHotKeyManager {
         if request.meta {
             modifiers |= MOD_WIN;
         }
+        modifiers |= MOD_NOREPEAT;
         let id = self.next_id.get();
         self.next_id.replace(id + 1);
-        self.hot_keys.borrow_mut().insert(id, handle);
         unsafe {
             let vk = MapVirtualKeyW(request.platform_code as u32, MAPVK_VSC_TO_VK);
             RegisterHotKey(Self::hwnd(), id, modifiers, vk);
         }
+        self.hot_keys.borrow_mut().insert(id, (handle, request));
         Ok(())
     }
 
     pub fn destroy_hot_key(&self, handle: HotKeyHandle) -> NativeExtensionsResult<()> {
         let mut hot_keys = self.hot_keys.borrow_mut();
 
-        let hot_key_id = hot_keys.iter().find(|f| f.1 == &handle).map(|e| *e.0);
+        let hot_key_id = hot_keys
+            .iter()
+            .find(|(_, (h, _))| h == &handle)
+            .map(|e| *e.0);
         if let Some(hot_key_id) = hot_key_id {
             hot_keys.remove(&hot_key_id);
             unsafe { UnregisterHotKey(Self::hwnd(), hot_key_id) };
@@ -90,11 +96,30 @@ impl PlatformHotKeyManager {
         Ok(())
     }
 
+    fn wait_until_release(
+        request: HotKeyCreateRequest,
+        handle: HotKeyHandle,
+        delegate: Rc<dyn HotKeyManagerDelegate>,
+    ) {
+        let vk = unsafe { MapVirtualKeyW(request.platform_code as u32, MAPVK_VSC_TO_VK) };
+        let key_state = unsafe { GetAsyncKeyState(vk as i32) };
+        if key_state < 0 {
+            RunLoop::current()
+                .schedule(Duration::from_millis(10), move || {
+                    Self::wait_until_release(request, handle, delegate);
+                })
+                .detach();
+        } else {
+            delegate.on_hot_key_released(handle);
+        }
+    }
+
     fn on_hot_key(&self, hot_key: i32) {
-        let handle = self.hot_keys.borrow().get(&hot_key).cloned();
+        let hot_key = self.hot_keys.borrow().get(&hot_key).cloned();
         let delegate = self.delegate.upgrade();
-        if let (Some(handle), Some(delegate)) = (handle, delegate) {
+        if let (Some((handle, request)), Some(delegate)) = (hot_key, delegate) {
             delegate.on_hot_key_pressed(handle);
+            Self::wait_until_release(request, handle, delegate);
         }
     }
 }

--- a/super_native_extensions/rust/src/win32/hot_key.rs
+++ b/super_native_extensions/rust/src/win32/hot_key.rs
@@ -11,9 +11,8 @@ use windows::Win32::{
     Foundation::HWND,
     UI::{
         Input::KeyboardAndMouse::{
-            GetAsyncKeyState, GetKeyState, MapVirtualKeyW, RegisterHotKey, UnregisterHotKey,
-            HOT_KEY_MODIFIERS, MAPVK_VSC_TO_VK, MOD_ALT, MOD_CONTROL, MOD_NOREPEAT, MOD_SHIFT,
-            MOD_WIN,
+            GetAsyncKeyState, MapVirtualKeyW, RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS,
+            MAPVK_VSC_TO_VK, MOD_ALT, MOD_CONTROL, MOD_NOREPEAT, MOD_SHIFT, MOD_WIN,
         },
         WindowsAndMessaging::WM_HOTKEY,
     },


### PR DESCRIPTION
This is a breaking change:

`HotKey.create` has been modifies:
   - removed `callback` argument
   - added `onPressed` and `onReleased` arguments

Fixes https://github.com/superlistapp/super_native_extensions/issues/232