### PR TITLE
chore: use ubuntu-20.04 for precompiled binaries

### DIFF
--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macOS-latest
           - windows-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
       - name: Install GTK
-        if: (matrix.os == 'ubuntu-latest')
+        if: (matrix.os == 'ubuntu-20.04')
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev
       - name: Precompile
         if: (matrix.os == 'macOS-latest') || (matrix.os == 'windows-latest')
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       - name: Precompile (with Android)
-        if: (matrix.os == 'ubuntu-latest')
+        if: (matrix.os == 'ubuntu-20.04')
         run: dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=24.0.8215888 --android-min-sdk-version=23
         working-directory: super_native_extensions/cargokit/build_tool
         env:


### PR DESCRIPTION
This is to done in order to link to order glibc version.