### PR TITLE
fix building under nixos

### DIFF
--- a/super_native_extensions/cargokit/run_build_tool.sh
+++ b/super_native_extensions/cargokit/run_build_tool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Very simple fix to build under NixOS.
On NixOS, /bin/bash is not here, so the build failed.
So it is much stronger to use /usr/bin/env bash.