### PR TITLE
fix: fit menu position to bounds after inflating

### DIFF
--- a/super_native_extensions/lib/src/drag_interaction/overlay_layout.dart
+++ b/super_native_extensions/lib/src/drag_interaction/overlay_layout.dart
@@ -85,14 +85,19 @@ class OverlayLayoutDelegate extends MultiChildLayoutDelegate {
     return ui.lerpDouble(maxFactor, minFactor, ratio)!;
   }
 
-  Rect _computePrimaryItemRect(Rect? menuPreviewRect, double liftFactor) {
+  Rect _computePrimaryItemRect({
+    required Rect bounds,
+    required Rect? menuPreviewRect,
+    required double liftFactor,
+  }) {
     final inflateFactor = 1.0 + (liftFactor - 1.0) * dragState.liftFactor;
     var rect = primaryItem.liftRect.inflateBy(inflateFactor);
 
     // If there is no custom menu preview use the size from lift rect.
     // This is similar behavior to iOS.
     if (!hasCustomMenuPreview && menuPreviewRect != null) {
-      menuPreviewRect = menuPreviewRect.inflateBy(inflateFactor);
+      menuPreviewRect =
+          menuPreviewRect.inflateBy(inflateFactor).fitIntoRect(bounds);
     }
 
     if (hasChild(menuPreviewId) && dragState.menuFactor > 0) {
@@ -167,8 +172,9 @@ class OverlayLayoutDelegate extends MultiChildLayoutDelegate {
     }
 
     final primaryItemRect = _computePrimaryItemRect(
-      menuPreviewRect,
-      _inflateFactorForSize(size),
+      bounds: bounds,
+      menuPreviewRect: menuPreviewRect,
+      liftFactor: _inflateFactorForSize(size),
     );
     _layoutChild(primaryItem.liftChildId, primaryItemRect);
     _layoutChild(primaryItem.dragChildId, primaryItemRect);


### PR DESCRIPTION
Fixes https://github.com/superlistapp/super_native_extensions/issues/317