### PR TITLE
Adds static instance getter to DefaultMobileMenuWidgetBuilder

### DIFF
--- a/super_context_menu/lib/src/default_builder/mobile_menu_widget_builder.dart
+++ b/super_context_menu/lib/src/default_builder/mobile_menu_widget_builder.dart
@@ -197,9 +197,8 @@ class DefaultMobileMenuWidgetBuilder extends MobileMenuWidgetBuilder {
     }
   }
 
-  static DefaultMobileMenuWidgetBuilder? _instance;
-  static DefaultMobileMenuWidgetBuilder get instance =>
-      _instance ??= DefaultMobileMenuWidgetBuilder();
+  static final DefaultMobileMenuWidgetBuilder instance =
+      DefaultMobileMenuWidgetBuilder();
 
   /// Allows overriding brightness for the menu UI.
   final Brightness? _brightness;

--- a/super_context_menu/lib/src/default_builder/mobile_menu_widget_builder.dart
+++ b/super_context_menu/lib/src/default_builder/mobile_menu_widget_builder.dart
@@ -197,6 +197,10 @@ class DefaultMobileMenuWidgetBuilder extends MobileMenuWidgetBuilder {
     }
   }
 
+  static DefaultMobileMenuWidgetBuilder? _instance;
+  static DefaultMobileMenuWidgetBuilder get instance =>
+      _instance ??= DefaultMobileMenuWidgetBuilder();
+
   /// Allows overriding brightness for the menu UI.
   final Brightness? _brightness;
 

--- a/super_context_menu/lib/src/menu.dart
+++ b/super_context_menu/lib/src/menu.dart
@@ -65,7 +65,7 @@ class ContextMenuWidget extends StatelessWidget {
   })  : assert(previewBuilder == null || deferredPreviewBuilder == null,
             'Cannot use both previewBuilder and deferredPreviewBuilder'),
         mobileMenuWidgetBuilder =
-            mobileMenuWidgetBuilder ?? DefaultMobileMenuWidgetBuilder(),
+            mobileMenuWidgetBuilder ?? DefaultMobileMenuWidgetBuilder.instance,
         desktopMenuWidgetBuilder =
             desktopMenuWidgetBuilder ?? DefaultDesktopMenuWidgetBuilder();
 


### PR DESCRIPTION
Calling `DeviceInfoPlugin().deviceInfo` for every instance of `ContextMenuWidget` is expensive if there are multiple ones created during single frame. This adds a static instance accessor to `DefaultMobileMenuWidgetBuilder` to reuse result of a single call to `DeviceInfoPlugin().deviceInfo`.