### PR TITLE
fix: ignore unknown pointer device kind

### DIFF
--- a/super_native_extensions/lib/src/gesture/pointer_device_kind.dart
+++ b/super_native_extensions/lib/src/gesture/pointer_device_kind.dart
@@ -14,7 +14,11 @@ class PointerDeviceKindDetector {
   }
 
   void _handleGlobalPointerEvent(PointerEvent event) {
-    _current.value = event.kind;
+    if (event.kind == PointerDeviceKind.unknown) {
+      // Happens on Android during drag & drop.
+    } else {
+      _current.value = event.kind;
+    }
   }
 
   static PointerDeviceKind _defaultDeviceKind() {


### PR DESCRIPTION
During drag & drop on Android there is single event with wrong pointer device kind causes number of unnecessary rebuilds.