### PR TITLE
fix: paste caused crash when clipboard is empty on linux 

### DIFF
--- a/super_native_extensions/rust/src/linux/clipboard_async.rs
+++ b/super_native_extensions/rust/src/linux/clipboard_async.rs
@@ -84,16 +84,20 @@ extern "C" fn on_targets(
     n_targets: c_int,
     completer: gpointer,
 ) {
-    let has_text = unsafe { gtk_targets_include_text(targets, n_targets) } != GFALSE;
-    let targets = unsafe { slice::from_raw_parts(targets, n_targets as usize) };
     let completer = completer as *mut FutureCompleter<Vec<String>>;
     let completer = unsafe { Box::from_raw(completer) };
-    let mut targets: Vec<_> = targets.iter().map(|t| t.to_string()).collect();
-    // Ensure we report our TEXT_TYPE
-    if has_text && !targets.iter().any(|a| a == TYPE_TEXT) {
-        targets.push(TYPE_TEXT.to_owned());
+    if n_targets > 0 {
+        let has_text = unsafe { gtk_targets_include_text(targets, n_targets) } != GFALSE;
+        let targets = unsafe { slice::from_raw_parts(targets, n_targets as usize) };
+        let mut targets: Vec<_> = targets.iter().map(|t| t.to_string()).collect();
+        // Ensure we report our TEXT_TYPE
+        if has_text && !targets.iter().any(|a| a == TYPE_TEXT) {
+            targets.push(TYPE_TEXT.to_owned());
+        }
+        completer.complete(targets);
+    } else {
+        completer.complete(vec![]);
     }
-    completer.complete(targets);
 }
 
 extern "C" fn on_text(_: *mut GtkClipboard, text: *const c_char, completer: gpointer) {


### PR DESCRIPTION
fix the crash when clipboard is empty (After system restart)
```
(example:19442): Gtk-CRITICAL **: 16:30:54.677: gtk_targets_include_text: assertion 'targets != NULL || n_targets == 0' failed
thread '<unnamed>' panicked at library/core/src/panicking.rs:220:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
   0:     0x72ac33718085 - std::backtrace_rs::backtrace::libunwind::trace::h1a07e5dba0da0cd2
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/../../backtrace/src/backtrace/libunwind.rs:105:5
   1:     0x72ac33718085 - std::backtrace_rs::backtrace::trace_unsynchronized::h61b9b8394328c0bc
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x72ac33718085 - std::sys_common::backtrace::_print_fmt::h1c5e18b460934cff
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:68:5
   3:     0x72ac33718085 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h1e1a1972118942ad
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x72ac3373b29b - core::fmt::rt::Argument::fmt::h07af2b4071d536cd
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/fmt/rt.rs:165:63
   5:     0x72ac3373b29b - core::fmt::write::hc090a2ffd6b28c4a
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/fmt/mod.rs:1157:21
   6:     0x72ac3371610f - std::io::Write::write_fmt::h8898bac6ff039a23
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/io/mod.rs:1832:15
   7:     0x72ac33717e5e - std::sys_common::backtrace::_print::h4e80c5803d4ee35b
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:47:5
   8:     0x72ac33717e5e - std::sys_common::backtrace::print::ha96650907276675e
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:34:9
   9:     0x72ac33719119 - std::panicking::default_hook::{{closure}}::h215c2a0a8346e0e0
  10:     0x72ac33718e5d - std::panicking::default_hook::h207342be97478370
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:298:9
  11:     0x72ac337195b3 - std::panicking::rust_panic_with_hook::hac8bdceee1e4fe2c
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:795:13
  12:     0x72ac3371945b - std::panicking::begin_panic_handler::{{closure}}::h00d785e82757ce3c
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:656:13
  13:     0x72ac33718549 - std::sys_common::backtrace::__rust_end_short_backtrace::h1628d957bcd06996
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:171:18
  14:     0x72ac337191c7 - rust_begin_unwind
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
  15:     0x72ac33445ed0 - core::panicking::panic_nounwind_fmt::runtime::habe92a792a272e00
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:110:18
  16:     0x72ac33445ed0 - core::panicking::panic_nounwind_fmt::h9763d8b18bc7b832
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:120:5
  17:     0x72ac33445f62 - core::panicking::panic_nounwind::h23e6f792ad66b857
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:220:5
  18:     0x72ac3348173c - core::slice::raw::from_raw_parts::precondition_check::h4851ea6a4331f5bf
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ub_checks.rs:66:21
  19:     0x72ac334eb01d - core::slice::raw::from_raw_parts::h424551f4b8380444
                               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ub_checks.rs:73:17
  20:     0x72ac3351b507 - super_native_extensions::platform_impl::platform::clipboard_async::on_targets::h7114f8caf8b23892
                               at /home/boyan/workspace/temp/super_native_extensions/super_native_extensions/rust/src/./linux/clipboard_async.rs:88:28
  21:     0x72ac34b9a673 - <unknown>
  22:     0x72ac34b99d91 - <unknown>
  23:     0x72ac3489958b - <unknown>
  24:     0x72ac343b16bd - <unknown>
  25:     0x72ac343b1a98 - g_signal_emit_by_name
  26:     0x72ac34a97274 - <unknown>
  27:     0x72ac348982f7 - <unknown>
  28:     0x72ac343b16bd - <unknown>
  29:     0x72ac343b17c1 - g_signal_emit_valist
  30:     0x72ac343b1883 - g_signal_emit
  31:     0x72ac34b66b74 - <unknown>
  32:     0x72ac34a042bf - gtk_main_do_event
  33:     0x72ac37a8d407 - <unknown>
  34:     0x72ac37ae6c6e - <unknown>
  35:     0x72ac342905b5 - <unknown>
  36:     0x72ac342ef717 - <unknown>
  37:     0x72ac3428fa53 - g_main_context_iteration
  38:     0x72ac344c688d - g_application_run
  39:     0x62a633a0f481 - main
                               at /home/boyan/workspace/temp/super_native_extensions/super_clipboard/example/linux/main.cc:5:10
  40:     0x72ac33a2a1ca - __libc_start_call_main
                               at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  41:     0x72ac33a2a28b - __libc_start_main_impl
                               at ./csu/../csu/libc-start.c:360:3
  42:     0x62a633a0f365 - _start
  43:                0x0 - <unknown>
thread caused non-unwinding panic. aborting.
```

according the documention, the `targets` can be null

https://docs.gtk.org/gtk3/callback.ClipboardTargetsReceivedFunc.html


