### PR TITLE
fix: synthesize_button_up might cause crash on Linux

### DIFF
--- a/super_native_extensions/rust/src/linux/common.rs
+++ b/super_native_extensions/rust/src/linux/common.rs
@@ -11,6 +11,7 @@ use gtk::{TargetEntry, TargetList};
 use gtk_sys::{gtk_target_table_new_from_list, gtk_targets_include_text};
 
 use crate::api_model::ImageData;
+use crate::error::{NativeExtensionsError::OtherError, NativeExtensionsResult};
 
 // Use gtk function to set/retrieve text (there are multiple possible format,
 // we don't want to mess with that)
@@ -100,13 +101,19 @@ pub fn surface_from_image_data(image: ImageData, opacity: f64) -> ImageSurface {
     res
 }
 
-pub(super) fn synthesize_button_up(event: &Event) -> Event {
-    if event.event_type() != EventType::ButtonPress {
-        panic!("Invalid event type");
+pub(super) fn synthesize_button_up(event: &Event) -> NativeExtensionsResult<Event> {
+    if event.event_type() != EventType::ButtonPress
+        && event.event_type() != EventType::DoubleButtonPress
+        && event.event_type() != EventType::TripleButtonPress
+    {
+        return Err(OtherError(format!(
+            "invalid button event: {}",
+            event.event_type()
+        )));
     }
     let mut event = event.clone();
     let e: *mut gdk_sys::GdkEvent = event.to_glib_none_mut().0;
     let e = unsafe { &mut *e };
     e.type_ = gdk_sys::GDK_BUTTON_RELEASE;
-    event
+    Ok(event)
 }

--- a/super_native_extensions/rust/src/linux/drag.rs
+++ b/super_native_extensions/rust/src/linux/drag.rs
@@ -220,7 +220,7 @@ impl PlatformDragContext {
             .ok_or_else(|| NativeExtensionsError::OtherError("Missing mouse event".into()))?;
 
         // release event will get eaten
-        let mut release = synthesize_button_up(&event);
+        let mut release = synthesize_button_up(&event)?;
         gtk::main_do_event(&mut release);
 
         let view = self.view()?;

--- a/super_native_extensions/rust/src/linux/menu.rs
+++ b/super_native_extensions/rust/src/linux/menu.rs
@@ -396,7 +396,7 @@ impl PlatformMenuContext {
             .last_event()
             .ok_or(NativeExtensionsError::MouseEventNotFound)?;
 
-        let mut release = synthesize_button_up(&event);
+        let mut release = synthesize_button_up(&event)?;
         gtk::main_do_event(&mut release);
 
         let view = self.view.upgrade().unwrap();


### PR DESCRIPTION
Fixes https://github.com/superlistapp/super_native_extensions/issues/403

https://docs.gtk.org/gdk3/struct.EventButton.html

> Used for button press and button release events. The type field will be one of GDK_BUTTON_PRESS, GDK_2BUTTON_PRESS, GDK_3BUTTON_PRESS or GDK_BUTTON_RELEASE,


when event is `DoubleButtonPress` or `TripleButtonPress`, there is an panic occur.