### PR TITLE
fix: Avoid adding duplicate listeners for drag-n-drop on the web

### DIFF
--- a/super_native_extensions/test/src/web/drop_test/listeners_empty_by_default_test.dart
+++ b/super_native_extensions/test/src/web/drop_test/listeners_empty_by_default_test.dart
@@ -1,0 +1,17 @@
+@TestOn('chrome')
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_native_extensions/src/web/drop.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  test('should have no listeners by default', () async {
+    expect(
+      web.document.getProperty(DropContextImpl.listenersProperty.toJS),
+      isNull,
+    );
+  });
+}

--- a/super_native_extensions/test/src/web/drop_test/save_listeners_for_removal_test.dart
+++ b/super_native_extensions/test/src/web/drop_test/save_listeners_for_removal_test.dart
@@ -1,0 +1,20 @@
+@TestOn('chrome')
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_native_extensions/src/web/drop.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  test('should save listeners for removal in the next initialization',
+      () async {
+    final context = DropContextImpl();
+    await context.initialize();
+    expect(
+      web.document.getProperty(DropContextImpl.listenersProperty.toJS),
+      hasLength(4),
+    );
+  });
+}

--- a/super_native_extensions/test/src/web/drop_test/should_replace_listeners_on_reinitialization.dart
+++ b/super_native_extensions/test/src/web/drop_test/should_replace_listeners_on_reinitialization.dart
@@ -1,0 +1,25 @@
+@TestOn('chrome')
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_native_extensions/src/web/drop.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  test('should replace listeners on reinitialization', () async {
+    final context = DropContextImpl();
+    await context.initialize();
+    final listenersA =
+        web.document.getProperty(DropContextImpl.listenersProperty.toJS);
+    await context.initialize();
+    final listenersB =
+        web.document.getProperty(DropContextImpl.listenersProperty.toJS);
+    expect(
+      listenersB,
+      hasLength(4),
+    );
+    expect(listenersA, isNot(listenersB));
+  });
+}


### PR DESCRIPTION
**The problem**

I noticed that on Web DOM listeners are added again on each reload/restart of the app and, during development, the number of events increased rapidly.

https://github.com/user-attachments/assets/64d9217e-1057-4060-8f74-c496395462eb

https://github.com/user-attachments/assets/bbea0cfe-c022-4a92-9a59-3f2367ed14c3

**The solution**
We can't account for it in dart land very easily, because even the dart context is thrown away and not even singletons survive. This is relevant because the listeners need to be saved somewhere in order to be removed later.

My solution is to attach the array of listeners as a DOM property, so that in the next initialization we can retrieve and remove them all.

**Bonus**

Tests were added for this. Just run:
```sh
flutter test --platform chrome
```