### PR TITLE
Replace `dart.library.js` with `dart.library.js_interop`.

### DIFF
--- a/super_clipboard/example/pubspec.lock
+++ b/super_clipboard/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -148,18 +148,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -236,7 +236,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -273,10 +273,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   super_clipboard:
     dependency: "direct main"
     description:
@@ -303,10 +303,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:

--- a/super_context_menu/example/pubspec.lock
+++ b/super_context_menu/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -132,18 +132,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -212,7 +212,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -249,10 +249,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   super_clipboard:
     dependency: "direct overridden"
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:

--- a/super_drag_and_drop/example/pubspec.lock
+++ b/super_drag_and_drop/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -148,18 +148,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -236,7 +236,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -273,10 +273,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   super_clipboard:
     dependency: "direct main"
     description:
@@ -332,10 +332,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:

--- a/super_keyboard_layout/example/pubspec.lock
+++ b/super_keyboard_layout/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -140,18 +140,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -220,7 +220,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -257,10 +257,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   super_keyboard_layout:
     dependency: "direct main"
     description:
@@ -287,10 +287,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:

--- a/super_native_extensions/lib/src/clipboard_events.dart
+++ b/super_native_extensions/lib/src/clipboard_events.dart
@@ -1,6 +1,6 @@
 import 'data_provider.dart';
 import 'native/clipboard_events.dart'
-    if (dart.library.js) 'web/clipboard_events.dart';
+    if (dart.library.js_interop) 'web/clipboard_events.dart';
 import 'reader.dart';
 
 abstract class ClipboardReadEvent {

--- a/super_native_extensions/lib/src/clipboard_reader.dart
+++ b/super_native_extensions/lib/src/clipboard_reader.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'native/clipboard_reader.dart'
-    if (dart.library.js) 'web/clipboard_reader.dart';
+    if (dart.library.js_interop) 'web/clipboard_reader.dart';
 import 'reader.dart';
 
 abstract class ClipboardReader {

--- a/super_native_extensions/lib/src/clipboard_writer.dart
+++ b/super_native_extensions/lib/src/clipboard_writer.dart
@@ -1,7 +1,7 @@
 import 'data_provider.dart';
 
 import 'native/clipboard_writer.dart'
-    if (dart.library.js) 'web/clipboard_writer.dart';
+    if (dart.library.js_interop) 'web/clipboard_writer.dart';
 
 abstract class ClipboardWriter {
   static final ClipboardWriter instance = ClipboardWriterImpl();

--- a/super_native_extensions/lib/src/data_provider_manager.dart
+++ b/super_native_extensions/lib/src/data_provider_manager.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'data_provider.dart';
 
 import 'native/data_provider_manager.dart'
-    if (dart.library.js) 'web/data_provider_manager.dart';
+    if (dart.library.js_interop) 'web/data_provider_manager.dart';
 
 abstract class DataProviderManager {
   static final DataProviderManager instance = DataProviderManagerImpl();

--- a/super_native_extensions/lib/src/drag.dart
+++ b/super_native_extensions/lib/src/drag.dart
@@ -9,7 +9,7 @@ import 'image_data.dart';
 import 'mutex.dart';
 import 'gesture/pointer_device_kind.dart';
 
-import 'native/drag.dart' if (dart.library.js) 'web/drag.dart';
+import 'native/drag.dart' if (dart.library.js_interop) 'web/drag.dart';
 import 'widget_snapshot/widget_snapshot.dart';
 
 class DragConfiguration {

--- a/super_native_extensions/lib/src/drop.dart
+++ b/super_native_extensions/lib/src/drop.dart
@@ -6,7 +6,7 @@ import 'mutex.dart';
 import 'reader.dart';
 import 'util.dart';
 
-import 'native/drop.dart' if (dart.library.js) 'web/drop.dart';
+import 'native/drop.dart' if (dart.library.js_interop) 'web/drop.dart';
 
 /// Represents result of a drag & drop operation.
 enum DropOperation {

--- a/super_native_extensions/lib/src/hot_key.dart
+++ b/super_native_extensions/lib/src/hot_key.dart
@@ -1,4 +1,4 @@
-import 'native/hot_key.dart' if (dart.library.js) 'web/hot_key.dart';
+import 'native/hot_key.dart' if (dart.library.js_interop) 'web/hot_key.dart';
 
 class HotKeyDefinition {
   final int platformCode;

--- a/super_native_extensions/lib/src/keyboard_layout.dart
+++ b/super_native_extensions/lib/src/keyboard_layout.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'native/keyboard_layout.dart'
-    if (dart.library.js) 'web/keyboard_layout.dart';
+    if (dart.library.js_interop) 'web/keyboard_layout.dart';
 
 import 'keyboard_layout_model.dart' as model;
 

--- a/super_native_extensions/lib/src/menu.dart
+++ b/super_native_extensions/lib/src/menu.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'menu_model.dart';
 import 'mutex.dart';
 
-import 'native/menu.dart' if (dart.library.js) 'web/menu.dart';
+import 'native/menu.dart' if (dart.library.js_interop) 'web/menu.dart';
 import 'menu_flutter.dart';
 import 'gesture/pointer_device_kind.dart';
 import 'widget_snapshot/widget_snapshot.dart';

--- a/super_native_extensions/lib/src/reader_manager.dart
+++ b/super_native_extensions/lib/src/reader_manager.dart
@@ -1,7 +1,7 @@
 import 'reader.dart';
 
 import 'native/reader_manager.dart'
-    if (dart.library.js) 'web/reader_manager.dart';
+    if (dart.library.js_interop) 'web/reader_manager.dart';
 
 // There is a separate $DataReaderHandle and $DataReaderItemHandle definition for
 // web and native. The typedef with $prefix is used within the web/native section

--- a/super_native_extensions/lib/src/widget_snapshot/widget_snapshotter.dart
+++ b/super_native_extensions/lib/src/widget_snapshot/widget_snapshotter.dart
@@ -6,7 +6,7 @@ import 'widget_snapshot.dart';
 import 'widget_snapshotter_internal.dart';
 
 import 'widget_snapshotter_native.dart'
-    if (dart.library.js) 'widget_snapshotter_web.dart';
+    if (dart.library.js_interop) 'widget_snapshotter_web.dart';
 
 typedef Translation = Offset Function(
   /// Snapshot rectangle in local coordinates.


### PR DESCRIPTION
This PR replaces all `dart.library.js` conditional imports with `dart.library.js_interop` to make it compatible with Wasm.

Potentially fixes #432 