### PR TITLE
fix(android) workaround to app crashes after copying an image and paste it on app restart

### DIFF
--- a/super_clipboard/example/android/build.gradle
+++ b/super_clipboard/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()

--- a/super_native_extensions/android/src/main/java/com/superlist/super_native_extensions/ClipDataHelper.java
+++ b/super_native_extensions/android/src/main/java/com/superlist/super_native_extensions/ClipDataHelper.java
@@ -92,7 +92,7 @@ public final class ClipDataHelper {
             res.add(typeTextPlain);
         }
 
-        ContentResolver contentProvider = context.getContentResolver();
+        ContentResolver contentResolver = context.getContentResolver();
         if (item.getUri() != null) {
             try {
                 readUriOrThrow(
@@ -100,13 +100,13 @@ public final class ClipDataHelper {
                         item.getUri()
                 );
             } catch (SecurityException e) {
-                Log.e(TAG, "Could not read the URI " + contentProvider.getType(item.getUri()) + " due to app lifecycle changes: " + e);
+                Log.e(TAG, "Could not read the URI " + contentResolver.getType(item.getUri()) + " due to app lifecycle changes: " + e);
                 return res.toArray(new String[0]);
             } catch (IOException e) {
-                Log.e(TAG, "Could not read the URI " + contentProvider.getType(item.getUri()) + " due to IO error: " + e);
+                Log.e(TAG, "Could not read the URI " + contentResolver.getType(item.getUri()) + " due to IO error: " + e);
                 return res.toArray(new String[0]);
             }
-            String[] types = contentProvider.getStreamTypes(item.getUri(), "*/*");
+            String[] types = contentResolver.getStreamTypes(item.getUri(), "*/*");
             if (types != null) {
                 for (String type : types) {
                     if (!res.contains(type)) {
@@ -114,7 +114,7 @@ public final class ClipDataHelper {
                     }
                 }
             } else {
-                String type = contentProvider.getType(item.getUri());
+                String type = contentResolver.getType(item.getUri());
                 if (type != null) {
                     res.add(type);
                 } else {


### PR DESCRIPTION
- *Partial Fix #435*

See [Before](https://streamable.com/0a0he6) and [After](https://streamable.com/1fp8m3) short videos.

This PR doesn't fix the issue, instead, it prevents the app crash, prints a warning, and then returns the formats array. This is not final and could use improvements. More details in #435.

[A similar workaround is used in `image_picker`](https://github.com/flutter/packages/blob/0fdf05f51029fd796fccd5ce8e4b4a908f71fd3a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java#L83-L87).