### PR TITLE
fix: build failure due to Android Studio dill files deletion (#460)

### DIFF
--- a/super_native_extensions/cargokit/run_build_tool.sh
+++ b/super_native_extensions/cargokit/run_build_tool.sh
@@ -77,6 +77,11 @@ if [ ! -f "$PACKAGE_HASH_FILE" ]; then
     echo "$PACKAGE_HASH" > "$PACKAGE_HASH_FILE"
 fi
 
+# Rebuild the tool if it was deleted by Android Studio
+if [ ! -f "bin/build_tool_runner.dill" ]; then
+  "$DART" compile kernel bin/build_tool_runner.dart
+fi
+
 set +e
 
 "$DART" bin/build_tool_runner.dill "$@"


### PR DESCRIPTION
Please see full context of that change here: https://github.com/superlistapp/super_native_extensions/issues/460

Let me know if this is good/safe to go. 
I've tested on my local machine (macOS) and it fixes the issue for me.