### PR TITLE
Updated precompile binaries workflow & fixes clippy warnings

### DIFF
--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: ubuntu22.04
+            distro: ubuntu22.04 # TODO change this to 20.04
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
@@ -74,8 +74,8 @@ jobs:
 
           run: |
             export FLUTTER_VERSION=stable
-            # export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
-            # export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
+            export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
+            export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
             git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git /flutter
             export PATH="$PATH:/flutter/bin"
             export PATH="$PATH":"$HOME/.pub-cache/bin"

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -46,7 +46,7 @@ jobs:
             distro: ubuntu22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
 
       - name: Build artifact
         uses: uraimo/run-on-arch-action@v3
@@ -74,12 +74,11 @@ jobs:
 
           run: |
             export FLUTTER_VERSION=stable
+            # export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
+            # export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
             git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git /flutter
             export PATH="$PATH:/flutter/bin"
             export PATH="$PATH":"$HOME/.pub-cache/bin"
             flutter doctor
-            git clone https://github.com/superlistapp/super_native_extensions.git
-            cd super_native_extensions
-            git fetch --depth=1 origin ee0669bd1cc54295c223e0bb666b733df41de1c5
-            git checkout ee0669bd1cc54295c223e0bb666b733df41de1c5
+            ls -la
             cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=26.3.11579264 --android-min-sdk-version=23

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -51,7 +51,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
-      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
 
       - name: Precompile
         uses: uraimo/run-on-arch-action@v3
@@ -65,12 +64,17 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                apt-get install -q -y libgtk-3-dev git curl unzip gcc
+                apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+                wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
+                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+                apt-get update -q -y
+                apt-get install -q -y dart
                 ;;
             esac
 
           run: |
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
+            export PATH="$PATH:/usr/lib/dart/bin"
             cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=chanderlud/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches: [main]
 
-
 name: Precompile Binaries
 
 jobs:
@@ -75,8 +74,6 @@ jobs:
 
           run: |
             export FLUTTER_VERSION=stable
-            export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
-            export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
             git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git /flutter
             export PATH="$PATH:/flutter/bin"
             export PATH="$PATH":"$HOME/.pub-cache/bin"

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macOS-latest
           - windows-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
       - name: Install GTK
-        if: (matrix.os == 'ubuntu-20.04')
+        if: (matrix.os == 'ubuntu-22.04')
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev
       - name: Precompile
         if: (matrix.os == 'macOS-latest') || (matrix.os == 'windows-latest')
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       - name: Precompile (with Android)
-        if: (matrix.os == 'ubuntu-20.04')
+        if: (matrix.os == 'ubuntu-22.04')
         run: dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=26.3.11579264 --android-min-sdk-version=23
         working-directory: super_native_extensions/cargokit/build_tool
         env:
@@ -36,7 +36,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   PrecompileCross:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Precompile (${{ matrix.distro }} ${{ matrix.arch }})
 
     strategy:
@@ -44,7 +44,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: ubuntu20.04
+            distro: ubuntu22.04
             target: aarch64-unknown-linux-gnu
             dart_arch: arm64
           - arch: riscv64

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
-  build_cross:
+  PrecompileCross:
     runs-on: ubuntu-20.04
     name: Precompile (${{ matrix.distro }} ${{ matrix.arch }})
 
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
 
-      - name: Build artifact
+      - name: Precompile
         uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.arch }}
@@ -73,8 +73,4 @@ jobs:
           run: |
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
-            # git clone --depth 1 --branch stable https://github.com/flutter/flutter.git /flutter
-            # export PATH="$PATH:/flutter/bin"
-            # export PATH="$PATH":"$HOME/.pub-cache/bin"
-            flutter doctor
             cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=chanderlud/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -67,7 +67,7 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                apt-get install -q -y libgtk-3-dev git curl
+                apt-get install -q -y libgtk-3-dev git curl unzip
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 ;;
             esac

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macOS-latest
           - windows-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
       - name: Install GTK
-        if: (matrix.os == 'ubuntu-20.04')
+        if: (matrix.os == 'ubuntu-22.04')
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev
       - name: Precompile
         if: (matrix.os == 'macOS-latest') || (matrix.os == 'windows-latest')
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       - name: Precompile (with Android)
-        if: (matrix.os == 'ubuntu-20.04')
+        if: (matrix.os == 'ubuntu-22.04')
         run: dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=26.3.11579264 --android-min-sdk-version=23
         working-directory: super_native_extensions/cargokit/build_tool
         env:
@@ -43,7 +43,8 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: ubuntu22.04 # TODO change this to 20.04
+            distro: ubuntu22.04
+            target: aarch64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
@@ -67,18 +68,17 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                apt-get install -q -y libgtk-3-dev git curl unzip
+                apt-get install -q -y libgtk-3-dev git curl unzip gcc
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 ;;
             esac
 
           run: |
-            export FLUTTER_VERSION=stable
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
-            git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git /flutter
+            git clone --depth 1 --branch stable https://github.com/flutter/flutter.git /flutter
             export PATH="$PATH:/flutter/bin"
             export PATH="$PATH":"$HOME/.pub-cache/bin"
             flutter doctor
             ls -la
-            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=26.3.11579264 --android-min-sdk-version=23
+            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -72,7 +72,7 @@ jobs:
                 apt-get update -q -y
                 apt-get install -q -y libgtk-3-dev git curl unzip gcc
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                curl -o dartsdk-linux-arm64-release.zip https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-${{ matrix.dart_arch }}-release.zip
+                curl -o dartsdk-linux-${{ matrix.dart_arch }}-release.zip https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-${{ matrix.dart_arch }}-release.zip
                 unzip dartsdk-linux-${{ matrix.dart_arch }}-release.zip
                 mv dart-sdk /usr/lib/dart
                 ;;

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -66,10 +66,11 @@ jobs:
                 apt-get update -q -y
                 apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https wget gnupg
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
-                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
-                apt-get update -q -y
-                apt-get install -q -y dart
+                curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/dart.gpg > /dev/null
+                ls -l /usr/share/keyrings/dart.gpg
+                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+                sudo apt-get update -q -y
+                sudo apt-get install -q -y dart
                 ;;
             esac
 

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -47,12 +47,8 @@ jobs:
             distro: ubuntu20.04
             target: aarch64-unknown-linux-gnu
             dart_arch: arm64
-          - arch: armv7
-            distro: ubuntu20.04
-            target: armv7-unknown-linux-gnueabihf
-            dart_arch: arm
           - arch: riscv64
-            distro: ubuntu20.04
+            distro: ubuntu22.04
             target: riscv64gc-unknown-linux-gnu
             dart_arch: riscv64
 
@@ -83,5 +79,4 @@ jobs:
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
             export PATH="$PATH:/usr/lib/dart/bin"
-            df -T ~/.cargo | awk '{print $2}' | tail -n 1
             cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=chanderlud/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -77,4 +77,4 @@ jobs:
             # export PATH="$PATH:/flutter/bin"
             # export PATH="$PATH":"$HOME/.pub-cache/bin"
             flutter doctor
-            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --target ${{ matrix.target }}
+            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=chanderlud/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-20.04
           - macOS-latest
           - windows-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
       - name: Install GTK
-        if: (matrix.os == 'ubuntu-22.04')
+        if: (matrix.os == 'ubuntu-20.04')
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev
       - name: Precompile
         if: (matrix.os == 'macOS-latest') || (matrix.os == 'windows-latest')
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       - name: Precompile (with Android)
-        if: (matrix.os == 'ubuntu-22.04')
+        if: (matrix.os == 'ubuntu-20.04')
         run: dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=26.3.11579264 --android-min-sdk-version=23
         working-directory: super_native_extensions/cargokit/build_tool
         env:
@@ -36,33 +36,30 @@ jobs:
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   build_cross:
-    runs-on: ubuntu-22.04
-    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+    runs-on: ubuntu-20.04
+    name: Precompile (${{ matrix.distro }} ${{ matrix.arch }})
 
     strategy:
       matrix:
         include:
           - arch: aarch64
-            distro: ubuntu22.04
+            distro: ubuntu20.04
             target: aarch64-unknown-linux-gnu
+          - arch: armv7
+            distro: ubuntu20.04
+            target: armv7-unknown-linux-gnueabihf
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
+      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d #1.6.0
 
       - name: Build artifact
         uses: uraimo/run-on-arch-action@v3
-        id: build
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}
           githubToken: ${{ github.token }}
           shell: /bin/bash
-
-          setup: |
-            mkdir -p "${PWD}/artifacts"
-
-          dockerRunArgs: |
-            --volume "${PWD}/artifacts:/artifacts"
 
           install: |
             case "${{ matrix.distro }}" in
@@ -76,9 +73,8 @@ jobs:
           run: |
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
-            git clone --depth 1 --branch stable https://github.com/flutter/flutter.git /flutter
-            export PATH="$PATH:/flutter/bin"
-            export PATH="$PATH":"$HOME/.pub-cache/bin"
+            # git clone --depth 1 --branch stable https://github.com/flutter/flutter.git /flutter
+            # export PATH="$PATH:/flutter/bin"
+            # export PATH="$PATH":"$HOME/.pub-cache/bin"
             flutter doctor
-            ls -la
             cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -64,7 +64,7 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https wget
+                apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https wget gnupg
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
                 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -67,7 +67,7 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                sudo apt-get update && sudo apt-get install libgtk-3-dev git curl -y
+                apt-get install -q -y libgtk-3-dev git curl
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 ;;
             esac

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -69,8 +69,8 @@ jobs:
                 curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/dart.gpg > /dev/null
                 ls -l /usr/share/keyrings/dart.gpg
                 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
-                sudo apt-get update -q -y
-                sudo apt-get install -q -y dart
+                apt-get update -q -y
+                apt-get install -q -y dart
                 ;;
             esac
 

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -45,9 +45,9 @@ jobs:
           - arch: aarch64
             distro: ubuntu20.04
             target: aarch64-unknown-linux-gnu
-          - arch: armv7
-            distro: ubuntu20.04
-            target: armv7-unknown-linux-gnueabihf
+          # - arch: armv7
+          #   distro: ubuntu20.04
+          #   target: armv7-unknown-linux-gnueabihf
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
@@ -64,13 +64,11 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https wget gnupg
+                apt-get install -q -y libgtk-3-dev git curl unzip gcc
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/dart.gpg > /dev/null
-                ls -l /usr/share/keyrings/dart.gpg
-                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
-                apt-get update -q -y
-                apt-get install -q -y dart
+                curl -o dartsdk-linux-arm64-release.zip https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-arm64-release.zip
+                unzip dartsdk-linux-arm64-release.zip
+                mv dart-sdk /usr/lib/dart
                 ;;
             esac
 

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -34,3 +34,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
+
+  build_cross:
+    runs-on: ubuntu-22.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build artifact
+        uses: uraimo/run-on-arch-action@v3
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          githubToken: ${{ github.token }}
+          shell: /bin/bash
+
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*)
+                apt-get update -q -y
+                sudo apt-get update && sudo apt-get install libgtk-3-dev git curl -y
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+                ;;
+            esac
+
+          run: |
+            export FLUTTER_VERSION=stable
+            export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
+            export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
+            git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git /flutter
+            export PATH="$PATH:/flutter/bin"
+            export PATH="$PATH":"$HOME/.pub-cache/bin"
+            flutter doctor
+            git clone https://github.com/superlistapp/super_native_extensions.git
+            cd super_native_extensions
+            git fetch --depth=1 origin ee0669bd1cc54295c223e0bb666b733df41de1c5
+            git checkout ee0669bd1cc54295c223e0bb666b733df41de1c5
+            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=26.3.11579264 --android-min-sdk-version=23

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -40,6 +40,7 @@ jobs:
     name: Precompile (${{ matrix.distro }} ${{ matrix.arch }})
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -82,4 +83,5 @@ jobs:
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
             export PATH="$PATH:/usr/lib/dart/bin"
+            df -T ~/.cargo | awk '{print $2}' | tail -n 1
             cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=chanderlud/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [main]
 
+
 name: Precompile Binaries
 
 jobs:

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -68,7 +68,7 @@ jobs:
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/dart.gpg > /dev/null
                 ls -l /usr/share/keyrings/dart.gpg
-                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
                 sudo apt-get update -q -y
                 sudo apt-get install -q -y dart
                 ;;

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -79,4 +79,4 @@ jobs:
             export GITHUB_TOKEN=${{ secrets.RELEASE_GITHUB_TOKEN }}
             export PRIVATE_KEY=${{ secrets.RELEASE_PRIVATE_KEY }}
             export PATH="$PATH:/usr/lib/dart/bin"
-            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=chanderlud/super_native_extensions --target ${{ matrix.target }}
+            cd super_native_extensions/cargokit/build_tool && dart run build_tool precompile-binaries -v --manifest-dir=../../rust --repository=superlistapp/super_native_extensions --target ${{ matrix.target }}

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -64,10 +64,10 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*)
                 apt-get update -q -y
-                apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https
+                apt-get install -q -y libgtk-3-dev git curl unzip gcc apt-transport-https wget
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
-                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+                wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
+                echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
                 apt-get update -q -y
                 apt-get install -q -y dart
                 ;;

--- a/.github/workflows/precompile_binaries.yml
+++ b/.github/workflows/precompile_binaries.yml
@@ -45,9 +45,15 @@ jobs:
           - arch: aarch64
             distro: ubuntu20.04
             target: aarch64-unknown-linux-gnu
-          # - arch: armv7
-          #   distro: ubuntu20.04
-          #   target: armv7-unknown-linux-gnueabihf
+            dart_arch: arm64
+          - arch: armv7
+            distro: ubuntu20.04
+            target: armv7-unknown-linux-gnueabihf
+            dart_arch: arm
+          - arch: riscv64
+            distro: ubuntu20.04
+            target: riscv64gc-unknown-linux-gnu
+            dart_arch: riscv64
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
@@ -66,8 +72,8 @@ jobs:
                 apt-get update -q -y
                 apt-get install -q -y libgtk-3-dev git curl unzip gcc
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                curl -o dartsdk-linux-arm64-release.zip https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-arm64-release.zip
-                unzip dartsdk-linux-arm64-release.zip
+                curl -o dartsdk-linux-arm64-release.zip https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-${{ matrix.dart_arch }}-release.zip
+                unzip dartsdk-linux-${{ matrix.dart_arch }}-release.zip
                 mv dart-sdk /usr/lib/dart
                 ;;
             esac

--- a/super_native_extensions/cargokit/build_tool/lib/src/target.dart
+++ b/super_native_extensions/cargokit/build_tool/lib/src/target.dart
@@ -52,10 +52,6 @@ class Target {
       flutter: 'linux-arm64',
     ),
     Target(
-      rust: 'armv7-unknown-linux-gnueabihf',
-      flutter: 'linux-arm',
-    ),
-    Target(
       rust: 'riscv64gc-unknown-linux-gnu',
       flutter: 'linux-riscv64',
     ),

--- a/super_native_extensions/cargokit/build_tool/lib/src/target.dart
+++ b/super_native_extensions/cargokit/build_tool/lib/src/target.dart
@@ -52,6 +52,14 @@ class Target {
       flutter: 'linux-arm64',
     ),
     Target(
+      rust: 'armv7-unknown-linux-gnueabihf',
+      flutter: 'linux-arm',
+    ),
+    Target(
+      rust: 'riscv64gc-unknown-linux-gnu',
+      flutter: 'linux-riscv64',
+    ),
+    Target(
       rust: 'x86_64-apple-darwin',
       darwinPlatform: 'macosx',
       darwinArch: 'x86_64',

--- a/super_native_extensions/rust/src/android/reader.rs
+++ b/super_native_extensions/rust/src/android/reader.rs
@@ -106,8 +106,8 @@ impl PlatformDataReader {
                 .await?;
             if let Value::String(url) = uri {
                 if let Ok(url) = Url::parse(&url) {
-                    if let Some(segments) = url.path_segments() {
-                        let last: Option<&str> = segments.last().filter(|s| !s.is_empty());
+                    if let Some(mut segments) = url.path_segments() {
+                        let last: Option<&str> = segments.next_back().filter(|s| !s.is_empty());
                         return Ok(last.map(|f| f.to_owned()));
                     }
                 }

--- a/super_native_extensions/rust/src/context.rs
+++ b/super_native_extensions/rust/src/context.rs
@@ -109,7 +109,7 @@ impl Drop for Context {
     fn drop(&mut self) {
         if self.outermost {
             // Remove attachment in reverse order in which they were inserted
-            while self.internal.attachments.borrow().len() > 0 {
+            while !self.internal.attachments.borrow().is_empty() {
                 let to_remove_index = self.internal.attachments.borrow().len() - 1;
                 let to_remove = self
                     .internal

--- a/super_native_extensions/rust/src/linux/reader.rs
+++ b/super_native_extensions/rust/src/linux/reader.rs
@@ -158,7 +158,7 @@ impl PlatformDataReader {
         let item = item as usize;
         let uri = self.inner.uris.get(item).and_then(|u| Url::parse(u).ok());
         if let Some(uri) = uri {
-            let name: Option<&str> = uri.path_segments().and_then(|s| s.last());
+            let name: Option<&str> = uri.path_segments().and_then(|mut s| s.next_back());
             match name {
                 Some(name) => {
                     let format = mime_from_name(name);

--- a/super_native_extensions/rust/src/linux/reader.rs
+++ b/super_native_extensions/rust/src/linux/reader.rs
@@ -143,8 +143,8 @@ impl PlatformDataReader {
         let item = item as usize;
         let uri = self.inner.uris.get(item).and_then(|u| Url::parse(u).ok());
         if let Some(uri) = uri {
-            if let Some(segments) = uri.path_segments() {
-                let last: Option<&str> = segments.last().filter(|s| !s.is_empty());
+            if let Some(mut segments) = uri.path_segments() {
+                let last: Option<&str> = segments.next_back().filter(|s| !s.is_empty());
                 return Ok(last.map(|f| f.to_owned()));
             }
         }


### PR DESCRIPTION
- Updates all Linux workflows to run on Ubuntu 22.04 as 20.04 is being deprecated
- Adds docker based compilation to precompile `aarch64-unknown-linux-gnu` and `riscv64gc-unknown-linux-gnu`
- Fixes clippy warnings with suggested changes