### PR TITLE
Propagate macos hotkey events

### DIFF
--- a/super_native_extensions/rust/src/darwin/macos/hot_key_sys.rs
+++ b/super_native_extensions/rust/src/darwin/macos/hot_key_sys.rs
@@ -87,3 +87,10 @@ extern "C" {
 extern "C" {
     pub fn GetEventDispatcherTarget() -> EventTargetRef;
 }
+
+extern "C" {
+    pub fn CallNextEventHandler(
+        inHandlerCallRef: EventHandlerCallRef,
+        inEvent: EventRef,
+    ) -> OSStatus;
+}


### PR DESCRIPTION
Hi, I ran into an issue with your plugin. I only use `super_drag_and_drop` and `super_clipboard`. But manage hotkeys directly in Swift via their `HotKey` package. 

Your native plugin seems to swallow all events on macos. This might make sense if `super_hot_key` is used, so not sure if this is a change you actually want to merge. However, for users of other plugins this can lead to some unintended side effects.