### PR TITLE
Add 16KB page size support for Android 15+

### DIFF
--- a/super_native_extensions/cargokit/build_tool/lib/src/android_environment.dart
+++ b/super_native_extensions/cargokit/build_tool/lib/src/android_environment.dart
@@ -186,7 +186,22 @@ class AndroidEnvironment {
     if (rustFlags.isNotEmpty) {
       rustFlags = '$rustFlags\x1f';
     }
-    rustFlags = '$rustFlags-L\x1f$workaroundDir';
+
+    // 16KB page size fix for Android 15+ (arm64-v8a and x86_64 only)
+    // https://github.com/superlistapp/super_native_extensions/issues/548
+    if (['arm64-v8a', 'x86_64'].contains(target.android)) {
+      rustFlags = '$rustFlags-L\x1f$workaroundDir\x1f';
+      const pageSizeArgs = [
+        '-C',
+        'link-arg=-Wl,--hash-style=both',
+        '-C',
+        'link-arg=-Wl,-z,max-page-size=16384',
+      ];
+      rustFlags = '$rustFlags${pageSizeArgs.join('\x1f')}';
+    } else {
+      rustFlags = '$rustFlags-L\x1f$workaroundDir';
+    }
+
     return rustFlags;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds support for Android 15+'s 16KB page size requirement by adding the necessary linker flags for `arm64-v8a` and `x86_64` architectures.

  Fixes #560

  ## Changes

  - Added `-Wl,-z,max-page-size=16384` linker flag for 16KB page alignment
  - Added `-Wl,--hash-style=both` for compatibility
  - Only applies to `arm64-v8a` and `x86_64` (as per Android documentation)

## Important Note

This fix only addresses `super_native_extensions`. For full 16KB compatibility, the dependency `irondash_engine_context` (from [irondash](https://github.com/irondash/irondash)) also needs the same linker flags applied. A similar PR should be raised there, or users will need to vendor/override `irondash_engine_context` with 16KB-aligned binaries.

  ## Testing Branch

  For anyone who wants to test immediately without Rust installed, I've published a branch with pre-built 16KB-aligned binaries (including vendored `irondash_engine_context`):

 ```
  dependency_overrides:
    super_native_extensions:
      git:
        url: https://github.com/dilumdesilva/super_native_extensions
        ref: main
```
   

 ### References

  - https://developer.android.com/guide/practices/page-sizes
  - Related issue: #548

  ### Testing

  - Built and verified ELF binaries show 0x4000 (16KB) alignment for LOAD segments
  - Tested on Android 15 device successfully