### PR TITLE
Fix RefCell re-entrancy panic during isolate cleanup

### DIFF
--- a/super_native_extensions/rust/src/drop_manager.rs
+++ b/super_native_extensions/rust/src/drop_manager.rs
@@ -248,7 +248,11 @@ impl AsyncMethodHandler for DropManager {
     }
 
     fn on_isolate_destroyed(&self, isolate: IsolateId) {
-        self.contexts.borrow_mut().remove(&isolate);
+        // Remove the context while the borrow is held, but bind the removed
+        // value so it is dropped after the temporary borrow guard is released.
+        // This prevents re-entrant RefCell borrows from destructors.
+        let removed = self.contexts.borrow_mut().remove(&isolate);
+        drop(removed);
     }
 }
 

--- a/super_native_extensions/rust/src/reader_manager.rs
+++ b/super_native_extensions/rust/src/reader_manager.rs
@@ -529,27 +529,36 @@ impl AsyncMethodHandler for DataReaderManager {
     }
 
     fn on_isolate_destroyed(&self, destroyed_isolate_id: IsolateId) {
-        let mut progresses = self.progresses.borrow_mut();
-        progresses.retain(|(isolate_id, _), progress| {
-            if *isolate_id == destroyed_isolate_id {
+        // Collect keys to remove while the borrow is held, then release the
+        // borrow before removing (and dropping) values. This prevents
+        // re-entrant RefCell borrows from destructors (e.g. DropNotifier).
+        let progress_keys: Vec<_> = self
+            .progresses
+            .borrow()
+            .keys()
+            .filter(|(isolate_id, _)| *isolate_id == destroyed_isolate_id)
+            .cloned()
+            .collect();
+        for key in progress_keys {
+            if let Some(progress) = self.progresses.borrow_mut().remove(&key) {
                 if let Some(progress) = progress.upgrade() {
                     progress.cancel();
                 }
-                false
-            } else {
-                true
             }
-        });
+        }
 
-        let mut readers = self.virtual_file_readers.borrow_mut();
-        readers.retain(|(isolate_id, _), reader| {
-            if *isolate_id == destroyed_isolate_id {
+        let reader_keys: Vec<_> = self
+            .virtual_file_readers
+            .borrow()
+            .keys()
+            .filter(|(isolate_id, _)| *isolate_id == destroyed_isolate_id)
+            .cloned()
+            .collect();
+        for key in reader_keys {
+            if let Some(reader) = self.virtual_file_readers.borrow_mut().remove(&key) {
                 reader.close().ok_log();
-                false
-            } else {
-                true
             }
-        })
+        }
     }
 
     async fn on_method_call(&self, call: MethodCall) -> PlatformResult {


### PR DESCRIPTION
## Summary

- Fixes a Rust panic (`RefCell<T> already mutably borrowed`) on Android when a Dart isolate exits
- During `on_isolate_destroyed`, a mutable `RefCell` borrow is held while `retain()` drops removed entries — their `DropNotifier` destructors attempt to re-borrow the same `RefCell`, causing a panic
- **drop_manager.rs**: Bind the removed value so it outlives the temporary borrow guard, ensuring the `RefCell` borrow is released before the value's destructors run
- **reader_manager.rs**: Collect keys to remove first (immutable borrow), then remove entries one at a time so each mutable borrow is scoped to a single `remove()` call

## Test plan

- [x] `cargo check` passes with no warnings
- [ ] Verify on Android that isolate cleanup no longer panics (reproducer from #571)

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)