### PR TITLE
Migrate to AGP9 and SDK36

### DIFF
--- a/super_native_extensions/android/build.gradle
+++ b/super_native_extensions/android/build.gradle
@@ -26,7 +26,7 @@ android {
         namespace 'com.superlist.super_native_extensions'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/super_native_extensions/cargokit/gradle/plugin.gradle
+++ b/super_native_extensions/cargokit/gradle/plugin.gradle
@@ -39,6 +39,9 @@ abstract class CargoKitBuildTask extends DefaultTask {
     @Input
     List<String> targetPlatforms
 
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
     @TaskAction
     def build() {
         if (project.cargokit.manifestDir == null) {
@@ -57,12 +60,12 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def rootProjectDir = project.rootProject.projectDir
 
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            project.exec {
+            execOperations.exec {
                 commandLine 'chmod', '+x', path
             }
         }
 
-        project.exec {
+        execOperations.exec {
             executable path
             args "build-gradle"
             environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir


### PR DESCRIPTION
Flutter 3.44 uses Android SDK 36 and AGP 9.0 by default, which causes this plugin to fail to compile. This PR attempts to fix this issue.