### PR TITLE
Use ExecOperations in CargoKit Gradle task

### DIFF
--- a/super_native_extensions/cargokit/gradle/plugin.gradle
+++ b/super_native_extensions/cargokit/gradle/plugin.gradle
@@ -42,24 +42,18 @@ abstract class CargoKitBuildTask extends DefaultTask {
     String pluginFile
 
     @Input
+    String manifestDir
+
+    @Input
+    String rootProjectDir
+
+    @Input
     List<String> targetPlatforms
 
     @TaskAction
     def build() {
-        if (project.cargokit.manifestDir == null) {
-            throw new GradleException("Property 'manifestDir' must be set on cargokit extension");
-        }
-
-        if (project.cargokit.libname == null) {
-            throw new GradleException("Property 'libname' must be set on cargokit extension");
-        }
-
         def executableName = Os.isFamily(Os.FAMILY_WINDOWS) ? "run_build_tool.cmd" : "run_build_tool.sh"
         def path = Paths.get(new File(pluginFile).parent, "..", executableName);
-
-        def manifestDir = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.manifestDir)
-
-        def rootProjectDir = project.rootProject.projectDir
 
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             execOperations.exec {
@@ -145,6 +139,14 @@ class CargoKitPlugin implements Plugin<Project> {
             // The task name depends on plugin properties, which are not available
             // at this point
             project.getGradle().afterProject {
+                if (project.cargokit.manifestDir == null) {
+                    throw new GradleException("Property 'manifestDir' must be set on cargokit extension");
+                }
+
+                if (project.cargokit.libname == null) {
+                    throw new GradleException("Property 'libname' must be set on cargokit extension");
+                }
+
                 def taskName = "cargokitCargoBuild${project.cargokit.libname.capitalize()}${buildType.capitalize()}";
 
                 if (project.tasks.findByName(taskName)) {
@@ -165,6 +167,8 @@ class CargoKitPlugin implements Plugin<Project> {
                     compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
                     targetPlatforms = platforms
                     pluginFile = CargoKitPlugin.file
+                    manifestDir = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.manifestDir).toString()
+                    rootProjectDir = project.rootProject.projectDir.toString()
                 }
                 def onTask = { newTask ->
                     if (newTask.name == "merge${buildType.capitalize()}NativeLibs") {

--- a/super_native_extensions/cargokit/gradle/plugin.gradle
+++ b/super_native_extensions/cargokit/gradle/plugin.gradle
@@ -1,5 +1,7 @@
 import java.nio.file.Paths
+import javax.inject.Inject
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
 
 CargoKitPlugin.file = buildscript.sourceFile
 
@@ -11,6 +13,9 @@ class CargoKitExtension {
 }
 
 abstract class CargoKitBuildTask extends DefaultTask {
+
+    @Inject
+    abstract ExecOperations getExecOperations()
 
     @Input
     String buildMode
@@ -57,13 +62,13 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def rootProjectDir = project.rootProject.projectDir
 
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            project.exec {
-                commandLine 'chmod', '+x', path
+            execOperations.exec {
+                commandLine 'chmod', '+x', path.toString()
             }
         }
 
-        project.exec {
-            executable path
+        execOperations.exec {
+            executable path.toString()
             args "build-gradle"
             environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir
             environment "CARGOKIT_TOOL_TEMP_DIR", "${buildDir}/build_tool"

--- a/super_native_extensions/cargokit/gradle/plugin.gradle
+++ b/super_native_extensions/cargokit/gradle/plugin.gradle
@@ -164,7 +164,8 @@ class CargoKitPlugin implements Plugin<Project> {
                     ndkVersion = plugin.project.android.ndkVersion
                     sdkDirectory = plugin.project.android.sdkDirectory
                     minSdkVersion = plugin.project.android.defaultConfig.minSdkVersion.apiLevel as int
-                    compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
+                    // AGP 9 reports e.g. "android-37.0" (minor SDK versions); keep only the major API level.
+                    compileSdkVersion = (plugin.project.android.compileSdkVersion.substring(8) =~ /\d+/)[0] as int
                     targetPlatforms = platforms
                     pluginFile = CargoKitPlugin.file
                     manifestDir = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.manifestDir).toString()


### PR DESCRIPTION
## Summary
- Replace deprecated project.exec calls in the CargoKit Gradle task with injected ExecOperations.
- Convert the Path executable values to strings for Gradle's exec API.

## Why
Gradle 9.x no longer allows this task's project.exec usage during execution. This causes Android release builds that depend on super_native_extensions to fail with:

> Could not find method exec() for arguments ... on project ':super_native_extensions'

This patch keeps the behavior the same while using Gradle's task-service exec API.