### PR TITLE
Fix Windows symlink resolution

### DIFF
--- a/super_native_extensions/cargokit/cmake/cargokit.cmake
+++ b/super_native_extensions/cargokit/cmake/cargokit.cmake
@@ -3,7 +3,7 @@ SET(cargokit_cmake_root "${CMAKE_CURRENT_LIST_DIR}/..")
 # Workaround for https://github.com/dart-lang/pub/issues/4010
 get_filename_component(cargokit_cmake_root "${cargokit_cmake_root}" REALPATH)
 
-if(WIN32)
+if(WIN32 AND CMAKE_VERSION VERSION_LESS "4.0")
     # REALPATH does not properly resolve symlinks on windows :-/
     execute_process(COMMAND powershell -ExecutionPolicy Bypass -File "${CMAKE_CURRENT_LIST_DIR}/resolve_symlinks.ps1" "${cargokit_cmake_root}" OUTPUT_VARIABLE cargokit_cmake_root OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()


### PR DESCRIPTION
CMake 4 no longer needs workaround