### PR TITLE
Guard clipboard format enumeration against SecurityException

### DIFF
--- a/super_native_extensions/android/src/main/java/com/superlist/super_native_extensions/ClipDataHelper.java
+++ b/super_native_extensions/android/src/main/java/com/superlist/super_native_extensions/ClipDataHelper.java
@@ -89,7 +89,18 @@ public final class ClipDataHelper {
             res.add(typeTextPlain);
         }
         if (item.getUri() != null) {
-            String[] types = context.getContentResolver().getStreamTypes(item.getUri(), "*/*");
+            // Some content providers (e.g. Google Photos' MediaContentProvider)
+            // are not exported and grant no read access to the pasting app, so
+            // querying them throws SecurityException. As this runs on the main
+            // thread while enumerating clipboard formats, an uncaught exception
+            // here crashes the whole app on paste. Guard both resolver calls and
+            // fall back to a plain URI type instead of crashing.
+            String[] types = null;
+            try {
+                types = context.getContentResolver().getStreamTypes(item.getUri(), "*/*");
+            } catch (Exception e) {
+                Log.w("ClipDataHelper", "getStreamTypes failed for clipboard uri", e);
+            }
             if (types != null) {
                 for (String type : types) {
                     if (!res.contains(type)) {
@@ -97,7 +108,12 @@ public final class ClipDataHelper {
                     }
                 }
             } else {
-                String type = context.getContentResolver().getType(item.getUri());
+                String type = null;
+                try {
+                    type = context.getContentResolver().getType(item.getUri());
+                } catch (Exception e) {
+                    Log.w("ClipDataHelper", "getType failed for clipboard uri", e);
+                }
                 if (type != null) {
                     res.add(type);
                 } else {


### PR DESCRIPTION
Fixes #589.

`ClipDataHelper.getFormats()` calls `ContentResolver.getStreamTypes()`/`getType()` on a clip item’s content URI while enumerating its formats. Some providers are not exported and grant the pasting app no read access — Google Photos’ `MediaContentProvider` is a common one — so these calls throw `SecurityException`. As this runs on the main thread while reading the clipboard, the uncaught exception crashes the entire app the moment the user pastes such an item.

This wraps both resolver calls in `try/catch` and falls back to `text/uri-list` when a URI is inaccessible, so it simply yields no stream types instead of crashing. No behaviour change for accessible URIs.