### PR TITLE
Fix Windows Build issues: #428

### DIFF
--- a/super_native_extensions/cargokit/cmake/resolve_symlinks.ps1
+++ b/super_native_extensions/cargokit/cmake/resolve_symlinks.ps1
@@ -22,7 +22,7 @@ function Resolve-Symlinks {
             $realPath += '/'
         }
 
-        $item = Get-Item $realPath
+        $item = Get-Item $realPath -Force 
         if ($item.LinkTarget) {
             $realPath = $item.LinkTarget.Replace('\', '/')
         }


### PR DESCRIPTION
AppData is hidden directory in windows so Get-Item return IO-Exception on it just add `-Force` Flag to allow read from the hidden directories